### PR TITLE
Adds function code_snippets_load_textdomain

### DIFF
--- a/code-snippets.php
+++ b/code-snippets.php
@@ -106,3 +106,12 @@ code_snippets()->load_plugin();
 
 /* Execute the snippets once the plugins are loaded */
 add_action( 'plugins_loaded', 'execute_active_snippets', 1 );
+
+/**
+ * Load plugin text domain
+ * @since 2.6.1
+ */
+function code_snippets_load_textdomain() {
+	load_plugin_textdomain( 'code-snippets', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'code_snippets_load_textdomain' );


### PR DESCRIPTION
Hi Shea,

greetings to Australia. I'm a Translation Editor for German translation of plugins, themes and WordPress core and worked a little on the translation of your great plugin. After correcting and adding some text strings I found out, the new translation doesn't get loaded as `load_plugin_textdomain()` is missing. There are plans to deprecate this function as it causes troubles with many translations and the automatic translation process with GlotPress, but for now I added the function in this patch.

I also saw, the "Dismiss" button in the feedback section misses a function to be translated, but will write a second pull request for that.

Greetings from Germany and thank you for providing your great plugin.
Best regards, Bego (@pixolin)