### PR TITLE
"Only run once" msgid missing + IT transaltion

### DIFF
--- a/languages/code-snippets-it_IT.po
+++ b/languages/code-snippets-it_IT.po
@@ -94,6 +94,10 @@ msgstr "Attivo solo nell'area admin"
 msgid "Only run on site front-end"
 msgstr "Attivo solo nell'area pubblica"
 
+#: php/admin-menus/class-edit-menu.php:339
+msgid "Only run once"
+msgstr "Esegui solo una volta"
+
 #: php/admin-menus/class-edit-menu.php:342
 msgid "Scope"
 msgstr "Scopo"


### PR DESCRIPTION
Added "Only run once" msgid
Added translated msgstr

Warning: the original english string was missing, not only the translation, please check if other translations are miss it as well!