### PR TITLE
More action hooks

### DIFF
--- a/js/edit-tags.js
+++ b/js/edit-tags.js
@@ -9,8 +9,8 @@ import 'tag-it/js/tag-it';
 
 	try {
 		jQuery(tags_field).tagit({
-			availableTags: code_snippets_all_tags,
-			allowSpaces: true,
+			availableTags: code_snippets_tags.options.availableTags,
+			allowSpaces: code_snippets_tags.options.allowSpaces,
 			removeConfirmation: true,
 			showAutocompleteOnFocus: true,
 		});

--- a/php/admin-menus/class-edit-menu.php
+++ b/php/admin-menus/class-edit-menu.php
@@ -636,7 +636,7 @@ class Code_Snippets_Edit_Menu extends Code_Snippets_Admin_Menu {
 			$actions['delete_snippet'] = __( 'Delete', 'code-snippets' );
 		}
 
-		return $actions;
+		return apply_filters( 'code_snippets/admin/submit_actions', $actions, $snippet, $extra_actions );
 	}
 
 	/**

--- a/php/admin-menus/class-edit-menu.php
+++ b/php/admin-menus/class-edit-menu.php
@@ -571,9 +571,17 @@ class Code_Snippets_Edit_Menu extends Code_Snippets_Admin_Menu {
 			);
 
 			$snippet_tags = wp_json_encode( get_all_snippet_tags() );
-			$inline_script = 'var code_snippets_all_tags = ' . $snippet_tags . ';';
 
-			wp_add_inline_script( 'code-snippets-edit-menu-tags', $inline_script, 'before' );
+			wp_localize_script(
+				'code-snippets-edit-menu-tags',
+				'code_snippets_tags',
+				array(
+					'options' => apply_filters( 'code_snippets/tag_it_options', array(
+						'availableTags' => get_all_snippet_tags(),
+						'allowSpaces'   => true,
+					) ),
+				)
+			);
 		}
 	}
 

--- a/php/views/edit.php
+++ b/php/views/edit.php
@@ -83,43 +83,7 @@ if ( ! $snippet->id ) {
 		</div>
 
 		<?php if ( apply_filters( 'code_snippets/extra_save_buttons', true ) ) { ?>
-			<p class="submit-inline">
-				<?php
-
-				$actions['save_snippet'] = array(
-					__( 'Save Changes', 'code-snippets' ),
-					__( 'Save Snippet', 'code-snippets' ),
-				);
-
-				if ( 'single-use' === $snippet->scope ) {
-					$actions['save_snippet_execute'] = array(
-						__( 'Execute Once', 'code-snippets' ),
-						__( 'Save Snippet and Execute Once', 'code-snippets' ),
-					);
-
-				} elseif ( ! $snippet->shared_network || ! is_network_admin() ) {
-
-					if ( $snippet->active ) {
-						$actions['save_snippet_deactivate'] = array(
-							__( 'Deactivate', 'code-snippets' ),
-							__( 'Save Snippet and Deactivate', 'code-snippets' ),
-						);
-
-					} else {
-						$actions['save_snippet_activate'] = array(
-							__( 'Activate', 'code-snippets' ),
-							__( 'Save Snippet and Activate', 'code-snippets' ),
-						);
-					}
-				}
-
-				foreach ( $actions as $action => $labels ) {
-					$other_attributes = array( 'title' => $labels[1], 'id' => $action . '_extra' );
-					submit_button( $labels[0], 'secondary small', $action, false, $other_attributes );
-				}
-
-				?>
-			</p>
+			<p class="submit-inline"><?php $this->render_submit_buttons( $snippet, '', false ); ?></p>
 		<?php } ?>
 
 		<h2>

--- a/php/views/edit.php
+++ b/php/views/edit.php
@@ -75,12 +75,16 @@ if ( ! $snippet->id ) {
 		printf( '<input type="hidden" name="snippet_active" value="%d" />', $snippet->active );
 
 		?>
+		<?php do_action( 'code_snippets/admin/before_title_input', $snippet ); ?>
+
 		<div id="titlediv">
 			<div id="titlewrap">
 				<label for="title" style="display: none;"><?php _e( 'Name', 'code-snippets' ); ?></label>
 				<input id="title" type="text" autocomplete="off" name="snippet_name" value="<?php echo esc_attr( $snippet->name ); ?>" placeholder="<?php _e( 'Enter title here', 'code-snippets' ); ?>" />
 			</div>
 		</div>
+
+		<?php do_action( 'code_snippets/admin/after_title_input', $snippet ); ?>
 
 		<?php if ( apply_filters( 'code_snippets/extra_save_buttons', true ) ) { ?>
 			<p class="submit-inline"><?php $this->render_submit_buttons( $snippet, '', false ); ?></p>

--- a/php/views/manage.php
+++ b/php/views/manage.php
@@ -42,6 +42,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$this->list_table->search_notice();
 		?></h1>
 
+	<?php do_action( 'code_snippets/admin/manage/before_list_table' ); ?>
+
 	<?php $this->list_table->views(); ?>
 
 	<form method="get" action="">


### PR DESCRIPTION
This PR makes it easier to extend/customize both the single edit and the list-table views by adding various action hooks and filters:

`apply_filters( 'code_snippets/admin/submit_actions', $actions, $snippet, $extra_actions )`
Allowing to add extra submit buttons to be added. I've also removed some code duplication from the  'extra save buttons' area by calling the `render_submit_buttons` method instead (allowing the same filter too hook in there).

`do_action( 'code_snippets/admin/before_title_input', $snippet );`
`do_action( 'code_snippets/admin/after_title_input', $snippet );`
`do_action( 'code_snippets/admin/manage/before_list_table' );`
Generic action hooks allowing custom elements to be inserted at the top parts of the pages too (a logical addition to the existing action hooks at the bottom)

```php
apply_filters( 'code_snippets/tag_it_options', array(
	'availableTags' => get_all_snippet_tags(),
	'allowSpaces'   => true,
) )
```
This is implemented using a `wp_localize_script` replacement for the current code using `wp_add_inline_script`, allowing for example to restrict the tags to a limited set, or expand them with a number of standard tags, as well as disabling spaces for tags (frontend only).