### PR TITLE
Add Site Health integration

### DIFF
--- a/php/class-admin.php
+++ b/php/class-admin.php
@@ -17,6 +17,13 @@ class Admin {
 	public $menus = array();
 
 	/**
+	 * The Site Health class instance.
+	 * 
+	 * @var Site_Health
+	 */
+	public $site_health;
+
+	/**
 	 * Class constructor
 	 */
 	public function __construct() {
@@ -57,6 +64,10 @@ class Admin {
 		if ( isset( $_POST['save_snippet'] ) && $_POST['save_snippet'] ) {
 			add_action( 'code_snippets/allow_execute_snippet', array( $this, 'prevent_exec_on_save' ), 10, 3 );
 		}
+
+		// Add Site Health integration.
+		$this->site_health = new Site_Health();
+		$this->site_health->hook();
 	}
 
 	/**

--- a/php/class-site-health.php
+++ b/php/class-site-health.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Code_Snippets;
+
+/**
+ * Functions specific to the Site Health page.
+ *
+ * @package Code_Snippets
+ */
+class Site_Health {
+
+	/**
+	 * Add hooks needed for functionality.
+	 */
+	public function hook() {
+		add_filter( 'debug_information', array( $this, 'debug_information' ) );
+	}
+
+	/**
+	 * Remove hooks needed for functionality.
+	 */
+	public function unhook() {
+		remove_filter( 'debug_information', array( $this, 'debug_information' ) );
+	}
+
+	/**
+	 * Add Code Snippets information to Site Health information.
+	 *
+	 * @param array $info The Site Health information.
+	 *
+	 * @return array The updated Site Health information.
+	 */
+	public function debug_information( $info ) {
+		$info['code-snippets'] = array(
+			'label'       => 'Code Snippets',
+			// @todo Plugin Author to replace this description.
+			'description' => 'You can put your description here',
+			'fields'      => array(
+				'code-snippets-active' => array(
+					'label' => 'Active Code Snippets',
+					// Split by | because line breaks don't get shown in the Dashboard UI (but they show on debug copy).
+					'value' => implode( " | \n", $this->get_active_code_snippets() ),
+				),
+			),
+		);
+
+		return $info;
+	}
+  
+	/**
+	 * Get the list of active code snippets.
+	 *
+	 * @return array List of active code snippets.
+	 */
+	public function get_active_code_snippets() {
+		$active_code_snippets = array();
+
+		$args = array(
+			'active_only' => true,
+			'limit'       => 100,
+		);
+
+		$snippets = get_snippets( array(), null, $args );
+
+		foreach ( $snippets as $snippet ) {
+			$active_code_snippets[] = $snippet->name . ' (' . trim( $snippet->scope . ': ' . $snippet->tags_list, ': ' ) . ')';
+		}
+
+		return $active_code_snippets;
+	}
+}


### PR DESCRIPTION
Fixes #117

Screencast of it in action: ![Screen Recording 2021-08-26 at 09 01 22 AM](https://user-images.githubusercontent.com/709662/130977410-21a78ea4-ca3a-40e7-a761-0b86a7b928ee.gif)

This PR adds Code Snippet information to the Site Health Info tab to assist all plugin developers in their support efforts.

**Note:** Line breaks / HTML _are not supported on this screen_, so things are separated with a ` | \n`. This allows separation between the different active snippets. The line break doesn't show up on the screen but it _does show up on when clicking the copy button_ to provide to plugin/theme support teams. This technique has been helpful for other projects I have integrated with Site Health.