### PR TITLE
Enable various common functionalities and shortcuts

### DIFF
--- a/code-snippets.php
+++ b/code-snippets.php
@@ -14,8 +14,8 @@
  */
 
 /*
-Author:       Code Snippets Pro
-Author URI:   https://codesnippets.pro
+Plugin Name: Code Snippets
+Plugin URI:  https://github.com/sheabunge/code-snippets
 Description:  An easy, clean and simple way to run code snippets on your site. No need to edit to your theme's functions.php file again!
 Author:       Code Snippets Pro
 Author URI:   https://codesnippets.pro

--- a/css/_editor.scss
+++ b/css/_editor.scss
@@ -102,3 +102,10 @@
 .CodeMirror .CodeMirror-linenumber {
 	color: #666;
 }
+
+.CodeMirror-foldmarker {
+	color: inherit;
+	margin-left: .25em;
+	margin-right: .25em;
+	font-weight: bold;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "url": "https://github.com/sheabunge/code-snippets/issues"
     },
     "dependencies": {
+        "@codemirror/fold": "^0.19.3",
         "@jcubic/tagger": "^0.4.1",
         "codemirror": "^5.65.0",
         "codemirror-colorpicker": "^1.9.80",

--- a/php/editor.php
+++ b/php/editor.php
@@ -31,6 +31,7 @@ function enqueue_code_editor( $type, $extra_atts = [] ) {
 
 	$default_atts = [
 		'mode'          => $modes[ $type ],
+		'inputStyle'    => 'textarea',
 		'matchBrackets' => true,
 		'extraKeys'     => [ 
 							'Alt-F' => 'findPersistent',

--- a/php/editor.php
+++ b/php/editor.php
@@ -35,6 +35,9 @@ function enqueue_code_editor( $type, $extra_atts = [] ) {
 		'extraKeys'     => [ 
 							'Alt-F' => 'findPersistent',
 							'Ctrl-Space' => 'autocomplete',
+							'Ctrl-/' => 'toggleComment',
+							'Alt-Up' => 'swapLineUp',
+							'Alt-Down' => 'swapLineDown',
 						],
 		'gutters'       => [ 'CodeMirror-lint-markers', 'CodeMirror-foldgutter'],
 		'lint'          => 'css' === $type || 'php' === $type,

--- a/php/editor.php
+++ b/php/editor.php
@@ -32,11 +32,15 @@ function enqueue_code_editor( $type, $extra_atts = [] ) {
 	$default_atts = [
 		'mode'          => $modes[ $type ],
 		'matchBrackets' => true,
-		'extraKeys'     => [ 'Alt-F' => 'findPersistent', 'Ctrl-Space' => 'autocomplete' ],
-		'gutters'       => [ 'CodeMirror-lint-markers' ],
+		'extraKeys'     => [ 
+							'Alt-F' => 'findPersistent',
+							'Ctrl-Space' => 'autocomplete',
+						],
+		'gutters'       => [ 'CodeMirror-lint-markers', 'CodeMirror-foldgutter'],
 		'lint'          => 'css' === $type || 'php' === $type,
 		'direction'     => 'ltr',
 		'colorpicker'   => [ 'mode' => 'edit' ],
+		'foldOptions' 	=> [ 'widget' => '...' ],
 	];
 
 	// add relevant saved setting values to the default attributes

--- a/php/settings/editor-preview.php
+++ b/php/settings/editor-preview.php
@@ -88,6 +88,8 @@ function render_editor_preview() {
 	$settings = get_settings_values();
 	$settings = $settings['editor'];
 
+	$settings['foldOptions'] = array( 'widget' => '...' );
+
 	$indent_unit = absint( $settings['indent_unit'] );
 	$tab_size = absint( $settings['tab_size'] );
 
@@ -97,10 +99,10 @@ function render_editor_preview() {
 	$indent = str_repeat( "\t", $n_tabs ) . str_repeat( ' ', $n_spaces );
 
 	$code = "add_filter( 'admin_footer_text', function ( \$text ) {\n\n" .
-	        $indent . "\$site_name = get_bloginfo( 'name' );\n\n" .
-	        $indent . '$text = "Thank you for visiting $site_name.";' . "\n" .
-	        $indent . 'return $text;' . "\n" .
-	        "} );\n";
+			$indent . "\$site_name = get_bloginfo( 'name' );\n\n" .
+			$indent . '$text = "Thank you for visiting $site_name.";' . "\n" .
+			$indent . 'return $text;' . "\n" .
+			"} );\n";
 
 	echo '<textarea id="code_snippets_editor_preview">', esc_textarea( $code ), '</textarea>';
 }

--- a/php/settings/settings-fields.php
+++ b/php/settings/settings-fields.php
@@ -215,6 +215,20 @@ function get_settings_fields() {
 			'default'    => true,
 			'codemirror' => 'styleActiveLine',
 		],
+		'keymap' => [
+			'name'       => __( 'Keymap', 'code-snippets' ),
+			'type'       => 'select',
+			'desc'       => __( 'The keymap to use in the editor.', 'code-snippets' ),
+			'default'    => 'default',
+			'options'    => [
+				'default' => __( 'Default', 'code-snippets' ),
+				'vim'     => __( 'Vim', 'code-snippets' ),
+				'emacs'   => __( 'Emacs', 'code-snippets' ),
+				'sublime' => __( 'Sublime Text', 'code-snippets' ),
+			],
+			'codemirror' => 'keyMap',
+		],
+
 	];
 
 	/** @noinspection PhpUnnecessaryLocalVariableInspection */

--- a/php/settings/settings-fields.php
+++ b/php/settings/settings-fields.php
@@ -176,6 +176,14 @@ function get_settings_fields() {
 			'codemirror' => 'lineWrapping',
 		],
 
+		'code_folding' => [
+			'name'       => __( 'Code Folding', 'code-snippets' ),
+			'type'       => 'checkbox',
+			'label'      => __( 'Allow folding functions or other blocks into a single line.', 'code-snippets' ),
+			'default'    => true,
+			'codemirror' => 'foldGutter',
+		],
+		
 		'line_numbers' => [
 			'name'       => __( 'Line Numbers', 'code-snippets' ),
 			'type'       => 'checkbox',

--- a/php/views/partials/editor-shortcuts.php
+++ b/php/views/partials/editor-shortcuts.php
@@ -24,10 +24,13 @@ namespace Code_Snippets;
 		'Shift'  => _x( 'Shift', 'keyboard key', 'code-snippets' ),
 		'Option' => _x( 'Option', 'keyboard key', 'code-snippets' ),
 		'Alt'    => _x( 'Alt', 'keyboard key', 'code-snippets' ),
+		'Up'	 => _x( 'Up', 'keyboard key', 'code-snippets' ),
+		'Down'   => _x( 'Down', 'keyboard key', 'code-snippets' ),
 		'F'      => _x( 'F', 'keyboard key', 'code-snippets' ),
 		'G'      => _x( 'G', 'keyboard key', 'code-snippets' ),
 		'R'      => _x( 'R', 'keyboard key', 'code-snippets' ),
 		'S'      => _x( 'S', 'keyboard key', 'code-snippets' ),
+		'/'      => _x( '/', 'keyboard key', 'code-snippets' ),
 	);
 
 	?>
@@ -79,6 +82,27 @@ namespace Code_Snippets;
 				<td><?php esc_html_e( 'Persistent search', 'code-snippets' ); ?></td>
 				<td>
 					<kbd><?php echo esc_html( $keys['Alt'] ); ?></kbd>&hyphen;<kbd><?php echo esc_html( $keys['F'] ); ?></kbd>
+				</td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Toggle Comment', 'code-snippets' ); ?></td>
+				<td>
+					<kbd class="pc-key"><?php echo esc_html( $keys['Ctrl'] ); ?></kbd><kbd class="mac-key"><?php
+						echo esc_html( $keys['Cmd'] ); ?></kbd>&hyphen;<kbd><?php echo esc_html( $keys['/'] ); ?></kbd>
+				</td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Swap Line Up', 'code-snippets' ); ?></td>
+				<td>
+					<kbd class="pc-key"><?php echo esc_html( $keys['Alt'] ); ?></kbd><kbd class="mac-key"><?php
+						echo esc_html( $keys['Option'] ); ?></kbd>&hyphen;<kbd><?php echo esc_html( $keys['Up'] ); ?></kbd>
+				</td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Swap Line Down', 'code-snippets' ); ?></td>
+				<td>
+					<kbd class="pc-key"><?php echo esc_html( $keys['Alt'] ); ?></kbd><kbd class="mac-key"><?php
+						echo esc_html( $keys['Option'] ); ?></kbd>&hyphen;<kbd><?php echo esc_html( $keys['Down'] ); ?></kbd>
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
This PR implements the functionalities discussed in #125:

- Toggle comments with `Ctrl + /`
- Swap lines up/down with `Alt + Up/Down`
- Enable code folding
- Enable keymaps included with the CodeMirror package (Vim, Emacs, Sublime)

Also fixes some duplicate plugin info attributes in `code-snippets.php` preventing the plugin to work.

I've made some comments on the changes too so we can discuss them in-place.