### PR TITLE
Move Theme select above editor preview

### DIFF
--- a/src/php/settings/settings-fields.php
+++ b/src/php/settings/settings-fields.php
@@ -134,14 +134,6 @@ function get_settings_fields(): array {
 	// Code Editor settings section.
 
 	$fields['editor'] = [
-		'theme' => [
-			'name'       => __( 'Theme', 'code-snippets' ),
-			'type'       => 'select',
-			'default'    => 'default',
-			'options'    => get_editor_theme_list(),
-			'codemirror' => 'theme',
-		],
-
 		'indent_with_tabs' => [
 			'name'       => __( 'Indent With Tabs', 'code-snippets' ),
 			'type'       => 'checkbox',
@@ -217,6 +209,7 @@ function get_settings_fields(): array {
 			'default'    => true,
 			'codemirror' => 'styleActiveLine',
 		],
+		
 		'keymap'                => [
 			'name'       => __( 'Keymap', 'code-snippets' ),
 			'type'       => 'select',
@@ -230,6 +223,14 @@ function get_settings_fields(): array {
 			],
 			'codemirror' => 'keyMap',
 		],
+
+		'theme' => [
+			'name'       => __( 'Theme', 'code-snippets' ),
+			'type'       => 'select',
+			'default'    => 'default',
+			'options'    => get_editor_theme_list(),
+			'codemirror' => 'theme',
+		],		
 	];
 
 	$fields = apply_filters( 'code_snippets_settings_fields', $fields );


### PR DESCRIPTION
fixes #206 for better UX having the theme selector further down the page closer to the Editor Preview to reduce scrolling when previewing themes. RE: https://github.com/codesnippetspro/code-snippets/issues/206