### PR TITLE
4 features to review in this PR

### DIFF
--- a/src/css/edit.scss
+++ b/src/css/edit.scss
@@ -152,3 +152,9 @@ p.snippet-scope, .snippet-scope p {
 .wrap .notice {
 	scroll-margin: 0.75em;
 }
+
+#edit-snippet-form-container .cs-sticky-notice {
+	position: sticky;
+	top: 40px;
+	z-index: 100;
+}

--- a/src/css/manage.scss
+++ b/src/css/manage.scss
@@ -60,12 +60,6 @@ $inactive-color: #ccc;
 	height: 17px;
 	border-radius: 34px;
 	background-color: #ccc;
-	box-shadow: 0 0px 1px 0px rgba(0, 0, 0, .2);
-    transition: all 200ms ease-in-out !important;
-
-	&:hover {
-		box-shadow: 0 1px 3px 0px rgba(0, 0, 0, 0.5);
-	}
 
 	&::before {
 		transition: all .4s;

--- a/src/css/manage.scss
+++ b/src/css/manage.scss
@@ -60,6 +60,12 @@ $inactive-color: #ccc;
 	height: 17px;
 	border-radius: 34px;
 	background-color: #ccc;
+	box-shadow: 0 0px 1px 0px rgba(0, 0, 0, .2);
+    transition: all 200ms ease-in-out !important;
+
+	&:hover {
+		box-shadow: 0 1px 3px 0px rgba(0, 0, 0, 0.5);
+	}
 
 	&::before {
 		transition: all .4s;
@@ -72,19 +78,11 @@ $inactive-color: #ccc;
 		border-radius: 50%;
 	}
 
-	&:hover::before {
-		transform: translateX(40%);
-	}
-
 	.snippets .active-snippet & {
 		background-color: $active-color;
 
 		&::before {
 			transform: translateX(100%);
-		}
-
-		&:hover::before {
-			transform: translateX(60%);
 		}
 	}
 

--- a/src/js/components/SnippetForm/fields/ScopeInput.tsx
+++ b/src/js/components/SnippetForm/fields/ScopeInput.tsx
@@ -7,6 +7,7 @@ import { buildShortcodeTag } from '../../../utils/shortcodes'
 import { getSnippetType } from '../../../utils/snippets'
 import { CopyToClipboardButton } from '../../common/CopyToClipboardButton'
 import { useSnippetForm } from '../../../hooks/useSnippetForm'
+import { truncateWords } from '../../../utils/text'
 import type { ShortcodeAtts } from '../../../utils/shortcodes'
 import type { SnippetScope } from '../../../types/Snippet'
 import type { Dispatch, SetStateAction} from 'react'
@@ -117,6 +118,7 @@ const ShortcodeInfo: React.FC = () => {
 				<>
 					<ShortcodeTag atts={{
 						id: snippet.id,
+						name: truncateWords(snippet.name),
 						network: snippet.network ?? isNetworkAdmin(),
 						...options
 					}} />

--- a/src/js/components/SnippetForm/page/Notices.tsx
+++ b/src/js/components/SnippetForm/page/Notices.tsx
@@ -2,11 +2,11 @@ import classnames from 'classnames'
 import React, { useEffect } from 'react'
 import { __, sprintf } from '@wordpress/i18n'
 import { useSnippetForm } from '../../../hooks/useSnippetForm'
-import type { MouseEventHandler, ReactNode} from 'react'
+import type { ReactNode } from 'react'
 
 interface DismissibleNoticeProps {
 	classNames?: classnames.Argument
-	onRemove: MouseEventHandler<HTMLButtonElement>
+	onRemove: VoidFunction
 	children?: ReactNode
 	autoHide?: boolean
 }
@@ -14,13 +14,10 @@ interface DismissibleNoticeProps {
 const DismissibleNotice: React.FC<DismissibleNoticeProps> = ({ classNames, onRemove, children, autoHide = true }) => {
 	useEffect(() => {
 		if (autoHide) {
-			const timer = setTimeout(() => {
-				onRemove({} as React.MouseEvent<HTMLButtonElement>)
-			}, 5000)
-			
+			const timer = setTimeout(onRemove, 5000)
 			return () => clearTimeout(timer)
 		}
-		return () => {} // eslint-disable-line
+		return undefined
 	}, [autoHide, onRemove])
 
 	return (
@@ -29,7 +26,7 @@ const DismissibleNotice: React.FC<DismissibleNoticeProps> = ({ classNames, onRem
 
 			<button type="button" className="notice-dismiss" onClick={event => {
 				event.preventDefault()
-				onRemove(event)
+				onRemove()
 			}}>
 				<span className="screen-reader-text">{__('Dismiss notice.', 'code-snippets')}</span>
 			</button>

--- a/src/js/components/SnippetForm/page/Notices.tsx
+++ b/src/js/components/SnippetForm/page/Notices.tsx
@@ -8,17 +8,23 @@ interface DismissibleNoticeProps {
 	classNames?: classnames.Argument
 	onRemove: MouseEventHandler<HTMLButtonElement>
 	children?: ReactNode
+	autoHide?: boolean
 }
 
-const DismissibleNotice: React.FC<DismissibleNoticeProps> = ({ classNames, onRemove, children }) => {
+const DismissibleNotice: React.FC<DismissibleNoticeProps> = ({ classNames, onRemove, children, autoHide = true }) => {
 	useEffect(() => {
-		if (window.CODE_SNIPPETS_EDIT?.scrollToNotices) {
-			window.scrollTo({ top: 0, behavior: 'smooth' })
+		if (autoHide) {
+			const timer = setTimeout(() => {
+				onRemove({} as React.MouseEvent<HTMLButtonElement>)
+			}, 5000)
+			
+			return () => clearTimeout(timer)
 		}
-	}, [])
+		return () => {} // eslint-disable-line
+	}, [autoHide, onRemove])
 
 	return (
-		<div id="message" className={classnames('notice fade is-dismissible', classNames)}>
+		<div id="message" className={classnames('cs-sticky-notice notice fade is-dismissible', classNames)}>
 			<>{children}</>
 
 			<button type="button" className="notice-dismiss" onClick={event => {
@@ -45,6 +51,7 @@ export const Notices: React.FC = () => {
 			<DismissibleNotice
 				classNames="error"
 				onRemove={() => setSnippet(previous => ({ ...previous, code_error: null }))}
+				autoHide={false}
 			>
 				<p>
 					<strong>{sprintf(

--- a/src/js/types/Shortcodes.ts
+++ b/src/js/types/Shortcodes.ts
@@ -5,6 +5,7 @@ export interface SourceShortcodeAtts {
 
 export interface ContentShortcodeAtts {
 	id: string
+	name: string
 	php: boolean
 	format: boolean
 	shortcodes: boolean

--- a/src/js/utils/text.ts
+++ b/src/js/utils/text.ts
@@ -6,3 +6,10 @@ export const trimLeadingChar = (text: string, character: string): string =>
 
 export const trimTrailingChar = (text: string, character: string): string =>
 	character === text.charAt(text.length - 1) ? text.slice(0, -1) : text
+
+export const truncateWords = (text: string, wordCount: number = 3): string => {
+	const words = text.trim().split(/\s+/);
+	return words.length > wordCount 
+		? `${words.slice(0, wordCount).join(' ')}...`
+		: text;
+};


### PR DESCRIPTION
@sheabunge @imantsk  - Please can you review the 4 changes made in this PR:

1. **Manage Snippets Page, effect of hover on toggle (linked to [issue 148](https://github.com/codesnippetspro/code-snippets/issues/148))** - user suggested that the movement of the toggle on hover is not a good UI experience and I agree, to enhance or give indication of interactivity I removed the movement on hover and added a background shadow. TBH most users will know what a toggle switch will do so we can even remove this altogether if feel there is no need.

2. **Nesting shortcodes (linked to [issue 198](https://github.com/codesnippetspro/code-snippets/issues/198) - further description there)** - by adding shortcodes [code-snippet "shortcodes"] without the "" in the code html snippet shortcode now allows the html snippet itself to contain another shortcode that will be rendered therefore allowing nested shortcodes. One limitation I just realised and haven't tested is that this may only allow one nested shortcode and not multiple, this could be an area of improvement for later on.

3. **Shortcode name attribute ([Issue 19](https://github.com/codesnippetspro/pro/issues/19))** - all html snippets where a shortcode is produced now include a name attribute which is the snippet name/ title capped to 3 words with trailing dots if longer to not make the shortcode so long...e.g. new format [code-snippets id=5 name='Test Snippet']

4. **Sticky admin notice (linked to [issue 208](https://github.com/codesnippetspro/code-snippets/issues/208) - principle based on user brandonjp suggestion)** - When saving a long snippet or any snippet the default behaviour is a scroll to top which shows the save admin notice, this change now removes this behaviour and instead makes the admin notice sticky so that it appears towards the top of the browser window so that if a user is editing a long snippet then they are not scrolled to top of page, and removes the notice automatically after 5 seconds.

