### PR TITLE
correcting laquo to lsaquo

### DIFF
--- a/src/php/cloud/list-table-shared-ops.php
+++ b/src/php/cloud/list-table-shared-ops.php
@@ -182,7 +182,7 @@ function cloud_lts_pagination( string $which, string $source, int $total_items, 
 		$page_links[] = '<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&laquo;</span>';
 	} else {
 		$page_links[] = sprintf(
-			'<a class="first-page button" href="%s"><span class="screen-reader-text">%s</span><span aria-hidden="true">&laquo;</span></a>',
+			'<a class="first-page button" href="%s"><span class="screen-reader-text">%s</span><span aria-hidden="true">&lsaquo;</span></a>',
 			esc_url( remove_query_arg( $source . '_page', $current_url ) ),
 			esc_html__( 'First page', 'code-snippets' )
 		);


### PR DESCRIPTION
So minor, but this has bugged me for a couple years. This previous page button atop the table nav should be `&lsaquo;` instead of `&laquo;`
![CleanShot 2025-02-02 at 14 27 00@2x-optimised png](https://github.com/user-attachments/assets/cf43bc4e-9de4-43d6-b386-34c22ec4cafc)
