### PR TITLE
re-correcting laquo to lsaquo in cloud table nav

### DIFF
--- a/src/php/cloud/list-table-shared-ops.php
+++ b/src/php/cloud/list-table-shared-ops.php
@@ -182,7 +182,7 @@ function cloud_lts_pagination( string $which, string $source, int $total_items, 
 		$page_links[] = '<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&laquo;</span>';
 	} else {
 		$page_links[] = sprintf(
-			'<a class="first-page button" href="%s"><span class="screen-reader-text">%s</span><span aria-hidden="true">&lsaquo;</span></a>',
+			'<a class="first-page button" href="%s"><span class="screen-reader-text">%s</span><span aria-hidden="true">&laquo;</span></a>',
 			esc_url( remove_query_arg( $source . '_page', $current_url ) ),
 			esc_html__( 'First page', 'code-snippets' )
 		);
@@ -192,7 +192,7 @@ function cloud_lts_pagination( string $which, string $source, int $total_items, 
 		$page_links[] = '<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&lsaquo;</span>';
 	} else {
 		$page_links[] = sprintf(
-			'<a class="prev-page button" href="%s"><span class="screen-reader-text">%s</span><span aria-hidden="true">&laquo;</span></a>',
+			'<a class="prev-page button" href="%s"><span class="screen-reader-text">%s</span><span aria-hidden="true">&lsaquo;</span></a>',
 			esc_url( add_query_arg( $source . '_page', max( 1, $current - 1 ), $current_url ) ),
 			esc_html__( 'Previous page', 'code-snippets' )
 		);


### PR DESCRIPTION
Well, good golly. I flipped 'em! 
 
In https://github.com/codesnippetspro/code-snippets/pull/215/commits/0c995dcdb79298378d5b0e379254f9a418b1bbe2 I did nothing of value for issue #215 .
 
This one adds value by placing the correct left single/double angle bracket in the cloud table nav.