### PR TITLE
Improve i18n, a11y, and security

### DIFF
--- a/src/js/components/SnippetForm/SnippetEditor/SnippetEditor.tsx
+++ b/src/js/components/SnippetForm/SnippetEditor/SnippetEditor.tsx
@@ -109,14 +109,12 @@ const SnippetTypeTabs: React.FC<SnippetTypeTabsProps> = ({
 				? <a
 					className="button button-large nav-tab-button nav-tab-inactive go-pro-button"
 					href="https://codesnippets.pro/pricing/"
-					title="Find more about Pro"
 					onClick={event => {
 						event.preventDefault()
 						openUpgradeDialog()
 					}}
 				>
-					{_x('Upgrade to ', 'Upgrade to Pro', 'code-snippets')}
-					<span className="badge">{_x('Pro', 'Upgrade to Pro', 'code-snippets')}</span>
+					{__('Upgrade to <span class="badge">Pro</span>', 'code-snippets')}
 				</a>
 				: null}
 		</h2>

--- a/src/js/components/SnippetForm/fields/ScopeInput.tsx
+++ b/src/js/components/SnippetForm/fields/ScopeInput.tsx
@@ -110,7 +110,7 @@ const ShortcodeInfo: React.FC = () => {
 					: __('After saving, you can copy a shortcode, or use the Classic Editor button, Block editor (Pro) or Elementor widget (Pro).', 'code-snippets')}
 				{' '}
 				<ExternalLink
-					href={__('https://help.codesnippets.pro/article/50-inserting-snippets', 'code-snippets')}
+					href="https://help.codesnippets.pro/article/50-inserting-snippets"
 				>
 					{__('Learn more', 'code-snippets')}
 				</ExternalLink>

--- a/src/php/admin-menus/class-import-menu.php
+++ b/src/php/admin-menus/class-import-menu.php
@@ -137,15 +137,22 @@ class Import_Menu extends Admin_Menu {
 				esc_html_e( 'No snippets were imported.', 'code-snippets' );
 
 			} else {
-				/* translators: 1: amount of snippets imported, 2: link to Snippets menu */
-				$text = _n(
-					'Successfully imported <strong>%1$d</strong> snippet. <a href="%2$s">Have fun!</a>',
-					'Successfully imported <strong>%1$d</strong> snippets. <a href="%2$s">Have fun!</a>',
-					$imported,
-					'code-snippets'
+				/* translators: %d: amount of snippets imported */
+				printf(
+					_n(
+						'Successfully imported %d snippet.',
+						'Successfully imported %d snippets.',
+						$imported,
+						'code-snippets'
+					),
+					'<strong>' . number_format_i18n(( $imported ) . '</strong>',
 				);
 
-				printf( wp_kses_post( $text ), esc_html( $imported ), esc_url( code_snippets()->get_menu_url( 'manage' ) ) );
+				printf(
+					' <a href="%s">%s</a>',
+					esc_url( code_snippets()->get_menu_url( 'manage' ) )
+					esc_html__( 'Have fun!', 'code-snippets' );
+				);
 			}
 
 			echo '</p></div>';

--- a/src/php/class-admin.php
+++ b/src/php/class-admin.php
@@ -128,7 +128,7 @@ class Admin {
 				'<a href="%1$s" title="%2$s" style="color: #d46f4d; font-weight: bold;" target="_blank">%3$s</a>',
 				'https://snipco.de/JE2i',
 				esc_attr__( 'Upgrade to Code Snippets Pro', 'code-snippets' ),
-				esc_attr__( 'Get Pro', 'code-snippets' )
+				esc_attr__( 'Upgrade to Pro', 'code-snippets' )
 			);
 		}
 		return $actions;

--- a/src/php/class-admin.php
+++ b/src/php/class-admin.php
@@ -103,7 +103,7 @@ class Admin {
 			return $actions;
 		}
 
-		$format = '<a href="%1$s" aria-label="%2$s">%3$s</a>';
+		$format = '<a href="%1$s" title="%2$s">%3$s</a>';
 
 		$actions = array_merge(
 			[
@@ -125,7 +125,7 @@ class Admin {
 
 		if ( ! code_snippets()->licensing->is_licensed() ) {
 			$actions[] = sprintf(
-				'<a href="%1$s" aria-label="%2$s" style="color: #d46f4d; font-weight: bold;" target="_blank">%3$s</a>',
+				'<a href="%1$s" title="%2$s" style="color: #d46f4d; font-weight: bold;" target="_blank">%3$s</a>',
 				'https://snipco.de/JE2i',
 				esc_attr__( 'Upgrade to Code Snippets Pro', 'code-snippets' ),
 				esc_attr__( 'Get Pro', 'code-snippets' )
@@ -148,7 +148,7 @@ class Admin {
 			return $plugin_meta;
 		}
 
-		$format = '<a href="%1$s" aria-label="%2$s" target="_blank">%3$s</a>';
+		$format = '<a href="%1$s" title="%2$s" target="_blank">%3$s</a>';
 
 		return array_merge(
 			$plugin_meta,
@@ -321,7 +321,7 @@ class Admin {
 
 		} elseif ( ! code_snippets()->licensing->is_licensed() && Plugin::is_pro_type( $type_name ) ) {
 			printf(
-				'<a class="nav-tab nav-tab-inactive" data-snippet-type="%s" aria-label="%s" href="https://codesnippets.pro/pricing/" target="_blank">',
+				'<a class="nav-tab nav-tab-inactive" data-snippet-type="%s" title="%s" href="https://codesnippets.pro/pricing/" target="_blank">',
 				esc_attr( $type_name ),
 				esc_attr__( 'Available in Code Snippets Pro (external link)', 'code-snippets' )
 			);

--- a/src/php/class-admin.php
+++ b/src/php/class-admin.php
@@ -103,20 +103,20 @@ class Admin {
 			return $actions;
 		}
 
-		$format = '<a href="%1$s" title="%2$s">%3$s</a>';
+		$format = '<a href="%1$s" aria-label="%2$s">%3$s</a>';
 
 		$actions = array_merge(
 			[
 				sprintf(
 					$format,
 					esc_url( code_snippets()->get_menu_url( 'settings' ) ),
-					esc_html__( 'Change plugin settings', 'code-snippets' ),
+					esc_attr__( 'Change plugin settings', 'code-snippets' ),
 					esc_html__( 'Settings', 'code-snippets' )
 				),
 				sprintf(
 					$format,
 					esc_url( code_snippets()->get_menu_url() ),
-					esc_html__( 'Manage your existing snippets', 'code-snippets' ),
+					esc_attr__( 'Manage your existing snippets', 'code-snippets' ),
 					esc_html__( 'Snippets', 'code-snippets' )
 				),
 			],
@@ -125,10 +125,10 @@ class Admin {
 
 		if ( ! code_snippets()->licensing->is_licensed() ) {
 			$actions[] = sprintf(
-				'<a href="%1$s" title="%2$s" style="color: #d46f4d; font-weight: bold;" target="_blank">%3$s</a>',
+				'<a href="%1$s" aria-label="%2$s" style="color: #d46f4d; font-weight: bold;" target="_blank">%3$s</a>',
 				'https://snipco.de/JE2i',
 				esc_attr__( 'Upgrade to Code Snippets Pro', 'code-snippets' ),
-				esc_html__( 'Get Pro', 'code-snippets' )
+				esc_attr__( 'Get Pro', 'code-snippets' )
 			);
 		}
 		return $actions;
@@ -148,7 +148,7 @@ class Admin {
 			return $plugin_meta;
 		}
 
-		$format = '<a href="%1$s" title="%2$s" target="_blank">%3$s</a>';
+		$format = '<a href="%1$s" aria-label="%2$s" target="_blank">%3$s</a>';
 
 		return array_merge(
 			$plugin_meta,
@@ -297,7 +297,7 @@ class Admin {
 		printf(
 			'<a href="%s" class="notice-dismiss"><span class="screen-reader-text">%s</span></a>',
 			esc_url( wp_nonce_url( add_query_arg( $meta_key, $notice ), $meta_key ) ),
-			esc_attr__( 'Dismiss', 'code-snippets' )
+			esc_html__( 'Dismiss', 'code-snippets' )
 		);
 
 		echo '</p></div>';
@@ -321,7 +321,7 @@ class Admin {
 
 		} elseif ( ! code_snippets()->licensing->is_licensed() && Plugin::is_pro_type( $type_name ) ) {
 			printf(
-				'<a class="nav-tab nav-tab-inactive" data-snippet-type="%s" title="%s" href="https://codesnippets.pro/pricing/" target="_blank">',
+				'<a class="nav-tab nav-tab-inactive" data-snippet-type="%s" aria-label="%s" href="https://codesnippets.pro/pricing/" target="_blank">',
 				esc_attr( $type_name ),
 				esc_attr__( 'Available in Code Snippets Pro (external link)', 'code-snippets' )
 			);

--- a/src/php/class-contextual-help.php
+++ b/src/php/class-contextual-help.php
@@ -72,7 +72,7 @@ class Contextual_Help {
 			'https://codesnippets.pro'                           => __( 'Plugin Website', 'code-snippets' ),
 		];
 
-		$contents = '<p><strong>' . esc_html__( 'For more information:', 'code-snippets' ) . "</strong></p>\n";
+		$contents = sprintf( "<p><strong>%s</strong></p>\n", esc_html__( 'For more information:', 'code-snippets' ) );
 
 		foreach ( $sidebar_links as $url => $label ) {
 			$contents .= "\n" . sprintf( '<p><a href="%s">%s</a></p>', esc_url( $url ), esc_html( $label ) );

--- a/src/php/class-contextual-help.php
+++ b/src/php/class-contextual-help.php
@@ -72,7 +72,7 @@ class Contextual_Help {
 			'https://codesnippets.pro'                           => __( 'Plugin Website', 'code-snippets' ),
 		];
 
-		$contents = '<p><strong>' . __( 'For more information:', 'code-snippets' ) . "</strong></p>\n";
+		$contents = '<p><strong>' . esc_html__( 'For more information:', 'code-snippets' ) . "</strong></p>\n";
 
 		foreach ( $sidebar_links as $url => $label ) {
 			$contents .= "\n" . sprintf( '<p><a href="%s">%s</a></p>', esc_url( $url ), esc_html( $label ) );

--- a/src/php/class-contextual-help.php
+++ b/src/php/class-contextual-help.php
@@ -136,7 +136,8 @@ class Contextual_Help {
 			[
 				__( 'Be sure to check your snippets for errors before you activate them, as a faulty snippet could bring your whole blog down. If your site starts doing strange things, deactivate all your snippets and activate them one at a time.', 'code-snippets' ),
 				__( "If something goes wrong with a snippet, and you can't use WordPress, you can cause all snippets to stop executing by turning on <strong>safe mode</strong>.", 'code-snippets' ),
-				__( 'You can find out how to enable safe mode in the <a href="https://help.codesnippets.pro/article/12-safe-mode">Code Snippets Pro Docs</a>.', 'code-snippets' ),
+				/* translators: %s: URL to Code Snippets Pro Docs */
+				sprintf( __( 'You can find out how to enable safe mode in the <a href="%s">Code Snippets Pro Docs</a>.', 'code-snippets' ), 'https://help.codesnippets.pro/article/12-safe-mode' )
 			]
 		);
 	}
@@ -151,7 +152,8 @@ class Contextual_Help {
 			[
 				$this->get_intro_text() .
 				__( 'Here you can add a new snippet, or edit an existing one.', 'code-snippets' ),
-				__( "If you're not sure about the types of snippets you can add, take a look at the <a href=\"https://help.codesnippets.pro/collection/2-adding-snippets\">Code Snippets Pro Docs</a> for inspiration.", 'code-snippets' ),
+				/* translators: %s: URL to Code Snippets Pro Docs */
+				sprintf( __( "If you're not sure about the types of snippets you can add, take a look at the <a href=\"%s\">Code Snippets Pro Docs</a> for inspiration.", 'code-snippets' ), 'https://help.codesnippets.pro/collection/2-adding-snippets' ),
 			]
 		);
 
@@ -160,7 +162,7 @@ class Contextual_Help {
 			__( 'Adding Snippets', 'code-snippets' ),
 			[
 				__( 'You need to fill out the name and code fields for your snippet to be added. While the description field will add more information about how your snippet works, what is does and where you found it, it is completely optional.', 'code-snippets' ),
-				__( 'Please be sure to check that your snippet is valid PHP code and will not produce errors before adding it through this page. While doing so will not become active straight away, it will help to minimise the chance of a faulty snippet becoming active on your site.', 'code-snippets' ),
+				__( 'Please be sure to check that your snippet is valid PHP code and will not produce errors before adding it through this page. While doing so will not become active straight away, it will help to minimize the chance of a faulty snippet becoming active on your site.', 'code-snippets' ),
 			]
 		);
 	}

--- a/src/php/class-list-table.php
+++ b/src/php/class-list-table.php
@@ -292,7 +292,7 @@ class List_Table extends WP_List_Table {
 		}
 
 		return sprintf(
-			'<a class="%s" href="%s" title="%s">&nbsp;</a> ',
+			'<a class="%s" href="%s" aria-label="%s">&nbsp;</a> ',
 			esc_attr( $class ),
 			esc_url( $this->get_action_link( $action, $snippet ) ),
 			esc_attr( $label )

--- a/src/php/class-list-table.php
+++ b/src/php/class-list-table.php
@@ -292,7 +292,7 @@ class List_Table extends WP_List_Table {
 		}
 
 		return sprintf(
-			'<a class="%s" href="%s" aria-label="%s">&nbsp;</a> ',
+			'<a class="%1$s" href="%2$s" title="%3$s" aria-label="%3$s">&nbsp;</a> ',
 			esc_attr( $class ),
 			esc_url( $this->get_action_link( $action, $snippet ) ),
 			esc_attr( $label )

--- a/src/php/cloud/class-cloud-search-list-table.php
+++ b/src/php/cloud/class-cloud-search-list-table.php
@@ -117,7 +117,7 @@ class Cloud_Search_List_Table extends WP_Plugin_Install_List_Table {
 		 */
 		foreach ( $this->items as $item ) {
 			?>
-			<div class="plugin-card cloud-search-card plugin-card-<?php echo sanitize_html_class( $item->id ); ?>">
+			<div class="plugin-card cloud-search-card plugin-card-<?php echo esc_attr( $item->id ); ?>">
 				<?php
 				cloud_lts_display_column_hidden_input( 'code', $item );
 				cloud_lts_display_column_hidden_input( 'name', $item );
@@ -132,7 +132,7 @@ class Cloud_Search_List_Table extends WP_Plugin_Install_List_Table {
 								printf( '<a href="%s">', esc_url( code_snippets()->get_snippet_edit_url( $link->local_id ) ) );
 							} else {
 								printf(
-									'<a href="%s" title="%s" class="cloud-snippet-preview thickbox" data-snippet="%s" data-lang="%s">',
+									'<a href="%s" aria-label="%s" class="cloud-snippet-preview thickbox" data-snippet="%s" data-lang="%s">',
 									'#TB_inline?&width=700&height=500&inlineId=show-code-preview',
 									esc_attr__( 'Preview this snippet', 'code-snippets' ),
 									esc_attr( $item->id ),
@@ -163,14 +163,12 @@ class Cloud_Search_List_Table extends WP_Plugin_Install_List_Table {
 						<p class="authors">
 							<cite>
 								<?php
-								esc_html_e( 'Codevault: ', 'code-snippets' );
-
 								printf(
-									'<a target="_blank" href="%s">%s</a>',
+									'%s <a target="_blank" href="%s">%s</a>',
+									esc_html__( 'Codevault:', 'code-snippets' );
 									esc_url( sprintf( 'https://codesnippets.cloud/codevault/%s', $item->codevault ) ),
 									esc_html( $item->codevault )
 								);
-
 								?>
 							</cite>
 						</p>
@@ -250,14 +248,22 @@ class Cloud_Search_List_Table extends WP_Plugin_Install_List_Table {
 						</div>
 					</div>
 					<div class="column-compatibility">
-						<strong><?php esc_html_e( 'WP Compatability:', 'code-snippets' ); ?></strong>
+						<strong><?php esc_html_e( 'WP Compatibility:', 'code-snippets' ); ?></strong>
 						<?php
 						if ( empty( $wp_tested ) ) {
-							echo '<span class="compatibility-untested">', esc_html__( 'Not indicated by author', 'code-snippets' ), '</span>';
+							printf(
+								'<span class="compatibility-untested">%s</span>',
+								esc_html__( 'Not indicated by author', 'code-snippets' )
+							);
 						} else {
-							// translators: tested status.
-							$text = sprintf( __( 'Author states %s', 'code-snippets' ), $wp_tested );
-							echo '<span class="compatibility-compatible">', esc_html( $text ), '</span>';
+							printf(
+								'<span class="compatibility-compatible">%s</span>',
+								sprintf(
+									// translators: %s: tested status.
+									__( 'Author states %s', 'code-snippets' ),
+									$wp_tested
+								)
+							);
 						}
 						?>
 					</div>

--- a/src/php/cloud/class-cloud-search-list-table.php
+++ b/src/php/cloud/class-cloud-search-list-table.php
@@ -132,7 +132,7 @@ class Cloud_Search_List_Table extends WP_Plugin_Install_List_Table {
 								printf( '<a href="%s">', esc_url( code_snippets()->get_snippet_edit_url( $link->local_id ) ) );
 							} else {
 								printf(
-									'<a href="%s" aria-label="%s" class="cloud-snippet-preview thickbox" data-snippet="%s" data-lang="%s">',
+									'<a href="%s" title="%s" class="cloud-snippet-preview thickbox" data-snippet="%s" data-lang="%s">',
 									'#TB_inline?&width=700&height=500&inlineId=show-code-preview',
 									esc_attr__( 'Preview this snippet', 'code-snippets' ),
 									esc_attr( $item->id ),

--- a/src/php/cloud/list-table-shared-ops.php
+++ b/src/php/cloud/list-table-shared-ops.php
@@ -125,7 +125,7 @@ function cloud_lts_build_action_links( Cloud_Snippet $cloud_snippet, string $sou
 	$thickbox_url = '#TB_inline?&width=700&height=500&inlineId=show-code-preview';
 
 	$thickbox_link = sprintf(
-		'<a href="%s" title="%s" class="cloud-snippet-preview cloud-snippet-preview-style thickbox %s" data-snippet="%s" data-lang="%s">%s</a>',
+		'<a href="%s" aria-label="%s" class="cloud-snippet-preview cloud-snippet-preview-style thickbox %s" data-snippet="%s" data-lang="%s">%s</a>',
 		esc_url( $thickbox_url ),
 		esc_attr( $cloud_snippet->name ),
 		$additional_classes,
@@ -224,7 +224,7 @@ function cloud_lts_pagination( string $which, string $source, int $total_items, 
 		$page_links[] = sprintf(
 			'<a class="next-page button" href="%s"><span class="screen-reader-text">%s</span><span aria-hidden="true">%s</span></a>',
 			esc_url( add_query_arg( $source . '_page', min( $total_pages, $current + 1 ), $current_url ) ),
-			__( 'Next page' ),
+			esc_html__( 'Next page', 'code-snippets' ),
 			'&rsaquo;'
 		);
 	}
@@ -235,7 +235,7 @@ function cloud_lts_pagination( string $which, string $source, int $total_items, 
 		$page_links[] = sprintf(
 			'<a class="last-page button" href="%s"><span class="screen-reader-text">%s</span><span aria-hidden="true">%s</span></a>',
 			esc_url( add_query_arg( $source . '_page', $total_pages, $current_url ) ),
-			__( 'Last page', 'code-snippets' ),
+			esc_html__( 'Last page', 'code-snippets' ),
 			'&raquo;'
 		);
 	}

--- a/src/php/front-end/class-front-end.php
+++ b/src/php/front-end/class-front-end.php
@@ -303,11 +303,12 @@ class Front_End {
 			}
 
 			/* translators: 1: snippet name, 2: snippet edit link */
-			$text = __( '<strong>%1$s</strong> is currently inactive. You can <a href="%2$s">edit this snippet</a> to activate it and make it visible. This message will not appear in the published post.', 'code-snippets' );
-
+			$text = __( '%1$s is currently inactive. You can <a href="%2$s">edit this snippet</a> to activate it and make it visible. This message will not appear in the published post.', 'code-snippets' );
+			$snippet_name = '<strong>' . $snippet->name . '</strong>';
 			$edit_url = add_query_arg( 'id', $snippet->id, code_snippets()->get_menu_url( 'edit' ) );
+
 			return wp_kses(
-				sprintf( $text, $snippet->name, $edit_url ),
+				sprintf( $text, $snippet_name, $edit_url ),
 				[
 					'strong' => [],
 					'a'      => [

--- a/src/php/views/manage.php
+++ b/src/php/views/manage.php
@@ -28,8 +28,11 @@ if ( false !== strpos( code_snippets()->version, 'beta' ) ) {
 		[ 'span' => [ 'class' => [ 'highlight-yellow' ] ] ]
 	);
 
-	$feedback_url = __( 'mailto:team@codesnippets.pro?subject=Code Snippet Beta Test Feedback', 'code-snippets' );
-	printf( ' <a href="%s">%s</a>', esc_url( $feedback_url ), esc_html__( 'Click here to submit your feedback', 'code-snippets' ) );
+	printf(
+		' <a href="%s">%s</a>',
+		esc_url( __( 'mailto:team@codesnippets.pro?subject=Code Snippet Beta Test Feedback', 'code-snippets' ) ),
+		esc_html__( 'Click here to submit your feedback', 'code-snippets' )
+	);
 	echo '</p></div>';
 }
 
@@ -58,7 +61,7 @@ if ( false !== strpos( code_snippets()->version, 'beta' ) ) {
 		?>
 		<a class="button button-large nav-tab-button nav-tab-inactive go-pro-button"
 		   href="https://codesnippets.pro/pricing/" target="_blank"
-		   title="<?php esc_html_e( 'Find more about Pro (opens in external tab)', 'code-snippets' ); ?>">
+		   aria-label="<?php esc_attr_e( 'Find more about Pro (opens in external tab)', 'code-snippets' ); ?>">
 			<?php echo wp_kses( __( 'Upgrade to <span class="badge">Pro</span>', 'code-snippets' ), [ 'span' => [ 'class' => 'badge' ] ] ); ?>
 			<span class="dashicons dashicons-external"></span>
 		</a>
@@ -79,7 +82,7 @@ if ( false !== strpos( code_snippets()->version, 'beta' ) ) {
 		],
 		'css'   => [
 			__( 'Style snippets are written in CSS and loaded in the admin area or on the site front-end, just like the theme style.css.', 'code-snippets' ),
-			esc_html__( 'Learn more about style snippets &rarr;', 'code-snippets' ),
+			__( 'Learn more about style snippets &rarr;', 'code-snippets' ),
 			'https://codesnippets.pro/learn-css/',
 		],
 		'js'    => [

--- a/src/php/views/partials/cloud-search.php
+++ b/src/php/views/partials/cloud-search.php
@@ -53,7 +53,7 @@ $cloud_select = sanitize_key( wp_unslash( $_REQUEST['cloud_select'] ?? '' ) );
 		</select>
 		<input type="text" id="cloud_search" name="cloud_search" class="cloud_search"
 		       value="<?php echo esc_html( $search_query ); ?>"
-		       placeholder="<?php esc_html_e( 'e.g. Remove unused javascript…', 'code-snippets' ); ?>">
+		       placeholder="<?php esc_attr_e( 'e.g. Remove unused javascript…', 'code-snippets' ); ?>">
 
 		<button type="submit" id="cloud-search-submit" class="button">
 			<?php esc_html_e( 'Search Cloud', 'code-snippets' ); ?>

--- a/src/php/views/partials/list-table-notices.php
+++ b/src/php/views/partials/list-table-notices.php
@@ -20,7 +20,7 @@ if ( defined( 'CODE_SNIPPETS_SAFE_MODE' ) && CODE_SNIPPETS_SAFE_MODE ) {
 		<p>
 			<?php
 			printf(
-				'<strong>%s:</strong> %s',
+				'<strong>%s</strong> %s',
 				esc_html__( 'Warning:', 'code-snippets' ),
 				sprintf(
 					// translators: 1: constant name, 2: file name.

--- a/src/php/views/partials/list-table-notices.php
+++ b/src/php/views/partials/list-table-notices.php
@@ -18,7 +18,18 @@ if ( defined( 'CODE_SNIPPETS_SAFE_MODE' ) && CODE_SNIPPETS_SAFE_MODE ) {
 	?>
 	<div id="message" class="notice notice-error fade is-dismissible">
 		<p>
-			<?php echo wp_kses_post( __( '<strong>Warning:</strong> Safe mode is active and snippets will not execute! Remove the <code>CODE_SNIPPETS_SAFE_MODE</code> constant from <code>wp-config.php</code> to turn off safe mode.', 'code-snippets' ) ); ?>
+			<?php
+			printf(
+				'<strong>%s:</strong> %s',
+				esc_html__( 'Warning:', 'code-snippets' ),
+				sprintf(
+					// translators: 1: constant name, 2: file name.
+					esc_html__( 'Safe mode is active and snippets will not execute! Remove the %1$s constant from %2$s file to turn off safe mode.', 'code-snippets' )
+					'<code>CODE_SNIPPETS_SAFE_MODE</code>',
+					'<code>wp-config.php</code>',
+				)
+			);
+			?>
 
 			<a href="https://help.codesnippets.pro/article/12-safe-mode" target="_blank">
 				<?php esc_html_e( 'Help', 'code-snippets' ); ?>

--- a/src/php/views/welcome.php
+++ b/src/php/views/welcome.php
@@ -80,7 +80,7 @@ $plugin_types = [
 		<h1>📰 <?php esc_html_e( 'Latest news', 'code-snippets' ); ?></h1>
 		<div class="csp-cards">
 			<a class="csp-card" href="<?php echo esc_url( $hero['follow_url'] ); ?>" target="_blank"
-			   title="<?php esc_html_e( 'Read more', 'code-snippets' ); ?>">
+			   aria-label="<?php esc_attr_e( 'Read more', 'code-snippets' ); ?>">
 				<header>
 					<span class="dashicons dashicons-external"></span>
 					<h2><?php echo esc_html( $hero['name'] ); ?></h2>
@@ -95,7 +95,7 @@ $plugin_types = [
 			</a>
 
 			<a class="csp-card" href="https://wordpress.org/plugins/code-snippets/changelog" target="_blank"
-			   title="<?php esc_html_e( 'Read the full changelog', 'code-snippets' ); ?>">
+				aria-label="<?php esc_attr_e( 'Read the full changelog', 'code-snippets' ); ?>">
 				<header>
 					<span class="dashicons dashicons-external"></span>
 					<h2><?php esc_html_e( 'Latest changes', 'code-snippets' ); ?></h2>
@@ -148,7 +148,7 @@ $plugin_types = [
 			<?php foreach ( $this->api->get_features() as $feature ) { ?>
 				<a class="csp-card"
 				   href="<?php echo esc_url( $feature['follow_url'] ); ?>" target="_blank"
-				   title="<?php esc_html_e( 'Read more', 'code-snippets' ); ?>">
+				   aria-label="<?php esc_attr_e( 'Read more', 'code-snippets' ); ?>">
 					<figure>
 						<img src="<?php echo esc_url( $feature['image_url'] ); ?>"
 						     alt="<?php esc_attr_e( 'Feature image', 'code-snippets' ); ?>">
@@ -172,7 +172,7 @@ $plugin_types = [
 			<?php foreach ( $this->api->get_partners() as $partner ) { ?>
 				<a class="csp-card"
 				   href="<?php echo esc_url( $partner['follow_url'] ); ?>" target="_blank"
-				   title="<?php esc_attr_e( 'Go to Partner', 'code-snippets' ); ?>">
+				   aria-label="<?php esc_attr_e( 'Go to Partner', 'code-snippets' ); ?>">
 					<figure>
 						<img src="<?php echo esc_url( $partner['image_url'] ); ?>"
 						     alt="<?php esc_attr_e( 'Partner image', 'code-snippets' ); ?>">

--- a/src/php/views/welcome.php
+++ b/src/php/views/welcome.php
@@ -80,7 +80,7 @@ $plugin_types = [
 		<h1>📰 <?php esc_html_e( 'Latest news', 'code-snippets' ); ?></h1>
 		<div class="csp-cards">
 			<a class="csp-card" href="<?php echo esc_url( $hero['follow_url'] ); ?>" target="_blank"
-				title="<?php esc_attr_e( 'Read more', 'code-snippets' ); ?>">
+			   title="<?php esc_attr_e( 'Read more', 'code-snippets' ); ?>">
 				<header>
 					<span class="dashicons dashicons-external"></span>
 					<h2><?php echo esc_html( $hero['name'] ); ?></h2>
@@ -95,7 +95,7 @@ $plugin_types = [
 			</a>
 
 			<a class="csp-card" href="https://wordpress.org/plugins/code-snippets/changelog" target="_blank"
-				title="<?php esc_attr_e( 'Read the full changelog', 'code-snippets' ); ?>">
+			   title="<?php esc_attr_e( 'Read the full changelog', 'code-snippets' ); ?>">
 				<header>
 					<span class="dashicons dashicons-external"></span>
 					<h2><?php esc_html_e( 'Latest changes', 'code-snippets' ); ?></h2>

--- a/src/php/views/welcome.php
+++ b/src/php/views/welcome.php
@@ -80,7 +80,7 @@ $plugin_types = [
 		<h1>📰 <?php esc_html_e( 'Latest news', 'code-snippets' ); ?></h1>
 		<div class="csp-cards">
 			<a class="csp-card" href="<?php echo esc_url( $hero['follow_url'] ); ?>" target="_blank"
-			   aria-label="<?php esc_attr_e( 'Read more', 'code-snippets' ); ?>">
+				title="<?php esc_attr_e( 'Read more', 'code-snippets' ); ?>">
 				<header>
 					<span class="dashicons dashicons-external"></span>
 					<h2><?php echo esc_html( $hero['name'] ); ?></h2>
@@ -95,7 +95,7 @@ $plugin_types = [
 			</a>
 
 			<a class="csp-card" href="https://wordpress.org/plugins/code-snippets/changelog" target="_blank"
-				aria-label="<?php esc_attr_e( 'Read the full changelog', 'code-snippets' ); ?>">
+				title="<?php esc_attr_e( 'Read the full changelog', 'code-snippets' ); ?>">
 				<header>
 					<span class="dashicons dashicons-external"></span>
 					<h2><?php esc_html_e( 'Latest changes', 'code-snippets' ); ?></h2>
@@ -148,7 +148,7 @@ $plugin_types = [
 			<?php foreach ( $this->api->get_features() as $feature ) { ?>
 				<a class="csp-card"
 				   href="<?php echo esc_url( $feature['follow_url'] ); ?>" target="_blank"
-				   aria-label="<?php esc_attr_e( 'Read more', 'code-snippets' ); ?>">
+				   title="<?php esc_attr_e( 'Read more', 'code-snippets' ); ?>">
 					<figure>
 						<img src="<?php echo esc_url( $feature['image_url'] ); ?>"
 						     alt="<?php esc_attr_e( 'Feature image', 'code-snippets' ); ?>">
@@ -172,7 +172,7 @@ $plugin_types = [
 			<?php foreach ( $this->api->get_partners() as $partner ) { ?>
 				<a class="csp-card"
 				   href="<?php echo esc_url( $partner['follow_url'] ); ?>" target="_blank"
-				   aria-label="<?php esc_attr_e( 'Go to Partner', 'code-snippets' ); ?>">
+				   title="<?php esc_attr_e( 'Go to Partner', 'code-snippets' ); ?>">
 					<figure>
 						<img src="<?php echo esc_url( $partner['image_url'] ); ?>"
 						     alt="<?php esc_attr_e( 'Partner image', 'code-snippets' ); ?>">


### PR DESCRIPTION
This PR fixes the following:

* Use the correct escaping functions for improved security (`esc_html_e` and `esc_attr_e`).
* Fix typos in strings.
* Split complex strings, to make easy to translate (remove HTML from the translation string).
* Add missing textdomain.
* WP 6.8 removed all the remaining `title` attributes, replacing them with `aria-label`.