### PR TITLE
Feat/ Adjustable font size to code editor

### DIFF
--- a/src/js/services/settings/editor-preview.ts
+++ b/src/js/services/settings/editor-preview.ts
@@ -41,7 +41,14 @@ export const handleEditorPreviewUpdates = () => {
 			})()
 
 			if (null !== value) {
-				editor?.setOption(opt, value)
+				if ('font_size' === setting.name) {
+					const codeElement = document.querySelector('.CodeMirror-code')
+					if (codeElement && codeElement instanceof HTMLElement) {
+						codeElement.style.fontSize = `${value}px`
+					}
+				} else {
+					editor?.setOption(opt, value)
+				}
 			}
 		})
 	}

--- a/src/php/editor.php
+++ b/src/php/editor.php
@@ -65,11 +65,11 @@ function enqueue_code_editor( string $type, array $extra_atts = [] ) {
 	foreach ( [ 'indentUnit', 'tabSize' ] as $number_att ) {
 		$atts[ $number_att ] = intval( $atts[ $number_att ] );
 	}
- 
-	// Remove fontsize from the options and add it as an inline style
+
+	// Remove fontSize from the options and add it as an inline style
 	if ( isset( $atts['fontSize'] ) ) {
 		$font_size = intval( $atts['fontSize'] );
-		unset( $atts['fontSize'] ); 
+		unset( $atts['fontSize'] );
 		wp_add_inline_style( 'code-editor', ".CodeMirror { font-size: {$font_size}px !important; }" );
 	}
 

--- a/src/php/editor.php
+++ b/src/php/editor.php
@@ -66,6 +66,15 @@ function enqueue_code_editor( string $type, array $extra_atts = [] ) {
 		$atts[ $number_att ] = intval( $atts[ $number_att ] );
 	}
 
+	//Manage font-szie setting with CSS since CodeMirror doesn't have a built-in option	
+	// Remove fontsize from the options and inject CSS
+	if ( isset( $atts['fontSize'] ) ) {
+		$font_size = intval( $atts['fontSize'] );
+		unset( $atts['fontSize'] ); 
+		// Add custom CSS
+		wp_add_inline_style( 'code-editor', ".CodeMirror { font-size: {$font_size}px !important; }" );
+	}
+
 	wp_enqueue_code_editor(
 		[
 			'type'       => $modes[ $type ],

--- a/src/php/editor.php
+++ b/src/php/editor.php
@@ -65,13 +65,11 @@ function enqueue_code_editor( string $type, array $extra_atts = [] ) {
 	foreach ( [ 'indentUnit', 'tabSize' ] as $number_att ) {
 		$atts[ $number_att ] = intval( $atts[ $number_att ] );
 	}
-
-	//Manage font-szie setting with CSS since CodeMirror doesn't have a built-in option	
-	// Remove fontsize from the options and inject CSS
+ 
+	// Remove fontsize from the options and add it as an inline style
 	if ( isset( $atts['fontSize'] ) ) {
 		$font_size = intval( $atts['fontSize'] );
 		unset( $atts['fontSize'] ); 
-		// Add custom CSS
 		wp_add_inline_style( 'code-editor', ".CodeMirror { font-size: {$font_size}px !important; }" );
 	}
 

--- a/src/php/editor.php
+++ b/src/php/editor.php
@@ -66,7 +66,7 @@ function enqueue_code_editor( string $type, array $extra_atts = [] ) {
 		$atts[ $number_att ] = intval( $atts[ $number_att ] );
 	}
 
-	// Remove fontSize from the options and add it as an inline style
+	// Remove fontSize from the options and add it as an inline style.
 	if ( isset( $atts['fontSize'] ) ) {
 		$font_size = intval( $atts['fontSize'] );
 		unset( $atts['fontSize'] );

--- a/src/php/settings/settings-fields.php
+++ b/src/php/settings/settings-fields.php
@@ -162,12 +162,21 @@ function get_settings_fields(): array {
 			'codemirror' => 'indentUnit',
 			'min'        => 0,
 		],
+		'font_size'                   => [
+			'name'       => __( 'Font Size', 'code-snippets' ),
+			'type'       => 'number',
+			'label'      => _x( 'px', 'unit', 'code-snippets' ),
+			'codemirror' => 'fontSize',
+			'min'        => 8,
+			'max'        => 28,
+		],
 		'wrap_lines'                  => [
 			'name'       => __( 'Wrap Lines', 'code-snippets' ),
 			'type'       => 'checkbox',
 			'label'      => __( 'Soft-wrap long lines of code instead of horizontally scrolling.', 'code-snippets' ),
 			'codemirror' => 'lineWrapping',
 		],
+
 		'code_folding'                => [
 			'name'       => __( 'Code Folding', 'code-snippets' ),
 			'type'       => 'checkbox',
@@ -215,14 +224,6 @@ function get_settings_fields(): array {
 			'type'       => 'select',
 			'options'    => get_editor_theme_list(),
 			'codemirror' => 'theme',
-		],
-		'font_size'                   => [
-			'name'       => __( 'Code Editor Font Size', 'code-snippets' ),
-			'type'       => 'number',
-			'label'      => _x( 'px', 'unit', 'code-snippets' ),
-			'codemirror' => 'fontSize',
-			'min'        => 8,
-			'max'        => 28,
 		],
 	];
 

--- a/src/php/settings/settings-fields.php
+++ b/src/php/settings/settings-fields.php
@@ -37,7 +37,7 @@ function get_default_settings(): array {
 			'indent_with_tabs'            => true,
 			'tab_size'                    => 4,
 			'indent_unit'                 => 4,
-			'font-size'                   => 14,
+			'font_size'                   => 14,
 			'wrap_lines'                  => true,
 			'code_folding'                => true,
 			'line_numbers'                => true,

--- a/src/php/settings/settings-fields.php
+++ b/src/php/settings/settings-fields.php
@@ -162,15 +162,6 @@ function get_settings_fields(): array {
 			'codemirror' => 'indentUnit',
 			'min'        => 0,
 		],
-		'font_size'                   => [
-			'name'       => __( 'Font Size', 'code-snippets' ),
-			'type'       => 'number',
-			'desc'       => __( 'The font size for the code editor.', 'code-snippets' ),
-			'label'      => _x( 'px', 'unit', 'code-snippets' ),
-			'codemirror' => 'fontSize',
-			'min'        => 8,
-			'max'        => 24,
-		],
 		'wrap_lines'                  => [
 			'name'       => __( 'Wrap Lines', 'code-snippets' ),
 			'type'       => 'checkbox',
@@ -224,6 +215,14 @@ function get_settings_fields(): array {
 			'type'       => 'select',
 			'options'    => get_editor_theme_list(),
 			'codemirror' => 'theme',
+		],
+		'font_size'                   => [
+			'name'       => __( 'Code Editor Font Size', 'code-snippets' ),
+			'type'       => 'number',
+			'label'      => _x( 'px', 'unit', 'code-snippets' ),
+			'codemirror' => 'fontSize',
+			'min'        => 8,
+			'max'        => 28,
 		],
 	];
 

--- a/src/php/settings/settings-fields.php
+++ b/src/php/settings/settings-fields.php
@@ -37,6 +37,7 @@ function get_default_settings(): array {
 			'indent_with_tabs'            => true,
 			'tab_size'                    => 4,
 			'indent_unit'                 => 4,
+			'font-size'                   => 14,
 			'wrap_lines'                  => true,
 			'code_folding'                => true,
 			'line_numbers'                => true,
@@ -160,6 +161,15 @@ function get_settings_fields(): array {
 			'label'      => _x( 'spaces', 'unit', 'code-snippets' ),
 			'codemirror' => 'indentUnit',
 			'min'        => 0,
+		],
+		'font_size'                   => [
+			'name'       => __( 'Font Size', 'code-snippets' ),
+			'type'       => 'number',
+			'desc'       => __( 'The font size for the code editor.', 'code-snippets' ),
+			'label'      => _x( 'px', 'unit', 'code-snippets' ),
+			'codemirror' => 'fontSize',
+			'min'        => 8,
+			'max'        => 24,
 		],
 		'wrap_lines'                  => [
 			'name'       => __( 'Wrap Lines', 'code-snippets' ),


### PR DESCRIPTION
This pull request introduces the Adjustable Font Size feature for the Code Editor.

It adds a new option within the Editor Settings panel, allowing users to set a custom font size. The selected value is applied via inline CSS to the .CodeMirror class.

When the user updates the font size in the settings panel, the code preview dynamically reflects the change without requiring a page reload.