### PR TITLE
fix: raise ecma version from 2018 to 2022

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,10 +30,10 @@ export default eslintTs.config(
 	},
 	{
 		languageOptions: {
-			ecmaVersion: 2018,
+			ecmaVersion: 2022,
 			globals: { ...globals.browser },
 			parserOptions: {
-				ecmaVersion: 2018,
+				ecmaVersion: 2022,
 				ecmaFeatures: { jsx: true },
 				tsconfigRootDir: import.meta.dirname,
 				projectService: { allowDefaultProject: ['eslint.config.mjs'] }


### PR DESCRIPTION
We are entering to 2026, it's time to update the 2018 ecma version.