### PR TITLE
Fix the position of "code direction" field in RTL mode

### DIFF
--- a/src/js/components/EditorSidebar/controls/RTLControl.tsx
+++ b/src/js/components/EditorSidebar/controls/RTLControl.tsx
@@ -6,7 +6,7 @@ export const RTLControl: React.FC = () => {
 	const { codeEditorInstance } = useSnippetForm()
 
 	return (
-		<div>
+		<div className="inline-form-field">
 			<h4>
 				<label htmlFor="snippet-code-direction">
 					{__('Code Direction', 'code-snippets')}


### PR DESCRIPTION
In RTL, the "code direction" field should be inline.

Before:

<img width="343" height="441" alt="Screenshot 2025-11-13 at 15 40 46" src="https://github.com/user-attachments/assets/9bfd61f8-6c08-4adc-be9e-cd624882c1e2" />

After:

<img width="337" height="402" alt="Screenshot 2025-11-13 at 15 42 02" src="https://github.com/user-attachments/assets/f3d9f6e3-b0a0-4c68-9808-13440080c6e0" />
