### PR TITLE
Fix: add missing translators comments

### DIFF
--- a/src/php/admin-menus/class-import-menu.php
+++ b/src/php/admin-menus/class-import-menu.php
@@ -137,8 +137,8 @@ class Import_Menu extends Admin_Menu {
 				esc_html_e( 'No snippets were imported.', 'code-snippets' );
 
 			} else {
-				/* translators: %d: amount of snippets imported */
 				printf(
+					// translators: %d: amount of snippets imported.
 					_n(
 						'Successfully imported %d snippet.',
 						'Successfully imported %d snippets.',

--- a/src/php/class-list-table.php
+++ b/src/php/class-list-table.php
@@ -618,6 +618,7 @@ class List_Table extends WP_List_Table {
 						continue 2;
 					}
 
+					// translators: %s: Websites count.
 					$shared_label_template = $this->is_network
 						? _n_noop(
 							'Shared with Subsites <span class="count">(%s)</span>',

--- a/src/php/settings/class-version-switch.php
+++ b/src/php/settings/class-version-switch.php
@@ -235,7 +235,11 @@ class Version_Switch {
 
 			return [
 				'success' => true,
-				'message' => sprintf( __( 'Successfully switched to version %s. Please refresh the page to see changes.', 'code-snippets' ), $target_version ),
+				'message' => sprintf(
+					// translators: %s: Version number.
+					__( 'Successfully switched to version %s. Please refresh the page to see changes.', 'code-snippets' ),
+					$target_version
+				),
 			];
 		}
 

--- a/src/php/views/partials/list-table-notices.php
+++ b/src/php/views/partials/list-table-notices.php
@@ -73,6 +73,7 @@ if ( 'deleted' === $result && ! empty( $_REQUEST['ids'] ) ) {
 	);
 
 	$result_messages['deleted'] = sprintf(
+		// translators: %s: Undo URL.
 		__( 'Snippet <strong>trashed</strong>. <a href="%s">Undo</a>', 'code-snippets' ),
 		esc_url( $undo_url )
 	);
@@ -90,6 +91,7 @@ if ( 'deleted-multi' === $result && ! empty( $_REQUEST['ids'] ) ) {
 	);
 
 	$result_messages['deleted-multi'] = sprintf(
+		// translators: %s: Undo URL.
 		__( 'Selected snippets <strong>trashed</strong>. <a href="%s">Undo</a>', 'code-snippets' ),
 		esc_url( $undo_url )
 	);


### PR DESCRIPTION
Minor update that fixes the following errors when testing the plugin with [WordPress plugin checker](https://wordpress.org/plugins/plugin-check/):

<img width="1533" height="883" alt="translators-comments" src="https://github.com/user-attachments/assets/ed376c02-b75b-46f8-8707-304bf98a2b54" />
