### PR TITLE
fix: add missing gap to what's new screen

### DIFF
--- a/src/css/welcome.scss
+++ b/src/css/welcome.scss
@@ -67,6 +67,7 @@ $breakpoint: 1060px;
 		display: flex;
 		flex-flow: row wrap;
 		justify-content: space-evenly;
+		gap: 5px;
 		margin: 0;
 	}
 


### PR DESCRIPTION
Before:

<img width="2192" height="178" alt="image" src="https://github.com/user-attachments/assets/6562d20b-9f83-4133-91ef-c574b0a6a326" />

After:

<img width="2192" height="180" alt="image" src="https://github.com/user-attachments/assets/02e74a5a-06e5-4de5-82ee-69e30f595287" />
