### PR TITLE
fix: beta issues

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -15,6 +15,20 @@ Severity labels used in this file:
 - **MUST** — Flag as a blocking issue; must be resolved before merge.
 - **SHOULD** — Flag as a recommendation; resolve before merge unless a risk-aware rationale is provided.
 
+## Practical Reviewer Checks
+
+- Don't silently widen types or drop generics when refactoring. If typing gets weaker, require a clear reason. [MUST]
+- In namespaced PHP, call WordPress globals with `\function_name()` and do not assume pluggable/core functions exist on very early execution paths. If a callback can run during early bootstrap, guard availability appropriately. [MUST]
+- Ensure hook callbacks that respond to options/actions are tightly gated to the intended option/action. Be suspicious of inverted or overly broad conditionals that can be triggered by other plugins. [MUST]
+- Avoid no-op abstractions (pass-through helpers, one-liner wrappers) unless they materially improve readability, reuse, or testability. [SHOULD]
+- Inline single-use extractions that do not clarify intent (local functions/variables used once). [SHOULD]
+- Prefer `undefined` for absent optional values in TypeScript/React unless `null` has explicit semantics in that API. [SHOULD]
+- For conditional class names, prefer the repository `classnames.classnames` helper over manual array filtering and joining. [SHOULD]
+- Prefer JSX for React markup. If a hook/util needs to render elements, suggest moving the markup into a `.tsx` component instead of using `createElement` in a `.ts` file. [SHOULD]
+- For simple key-to-value parsing/transforms, prefer a literal object/record map over a loop + `switch` when it improves clarity. [SHOULD]
+- Do not stack redundant `catch` blocks (e.g., `ParseError` plus `Throwable`) unless the handlers differ. [SHOULD]
+- When a screen is React-driven, question heavy PHP view logic. If PHP is used due to WordPress admin primitives (e.g., Screen Options, non-REST file streaming), require a short rationale. [SHOULD]
+
 ## Scope and Diff Hygiene
 
 - Flag PRs that mix behavior changes with refactors, renames, or formatting-only edits. Each change should be single-purpose. [MUST]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,11 @@ export default eslintTs.config(
 		rules: reactHooks.configs.recommended.rules,
 	},
 	{
-		ignores: ['bundle/*', 'src/dist/*', 'src/vendor/*', 'svn/*', '*.config.mjs', '*.config.js', '.*/*', 'tmp/*']
+		ignores: [
+			'bundle/*', 'src/dist/*', 'src/vendor/*', 'svn/*',
+			'*.config.mjs', '*.config.js',
+			'.*/*', 'tmp/*', 'playwright-report/*'
+		]
 	},
 	{
 		languageOptions: {

--- a/src/css/common/_notices.scss
+++ b/src/css/common/_notices.scss
@@ -1,11 +1,29 @@
 .code-snippets-notice {
-	a.notice-dismiss {
-		text-decoration: none;
+	.notice-dismiss {
+		position: absolute;
+		transform: initial;
+		inset-inline-end: 0;
+		inset-block-start: 0;
 	}
 
-	details pre {
-		max-inline-size: 100%;
-		overflow: auto hidden;
-		white-space: pre;
+	details[open]::after{
+		content: "Scroll horizontally if the trace is cut off";
+		font-style: italic;
+		opacity: 0.5;
+	}
+
+	details {
+		margin: .5em 0;
+		padding: 2px;
+
+		summary {
+			cursor: pointer;
+		}
+
+		pre {
+			max-inline-size: 100%;
+			overflow: auto hidden;
+			white-space: pre;
+		}
 	}
 }

--- a/src/css/common/_notices.scss
+++ b/src/css/common/_notices.scss
@@ -6,12 +6,6 @@
 		inset-block-start: 0;
 	}
 
-	details[open]::after{
-		content: "Scroll horizontally if the trace is cut off";
-		font-style: italic;
-		opacity: 0.5;
-	}
-
 	details {
 		margin: .5em 0;
 		padding: 2px;
@@ -24,6 +18,10 @@
 			max-inline-size: 100%;
 			overflow: auto hidden;
 			white-space: pre;
+		}
+
+		.stack-trace-hint {
+			opacity: 0.5;
 		}
 	}
 }

--- a/src/css/common/_notices.scss
+++ b/src/css/common/_notices.scss
@@ -1,0 +1,11 @@
+.code-snippets-notice {
+	a.notice-dismiss {
+		text-decoration: none;
+	}
+
+	details pre {
+		max-inline-size: 100%;
+		overflow: auto hidden;
+		white-space: pre;
+	}
+}

--- a/src/css/edit.scss
+++ b/src/css/edit.scss
@@ -29,6 +29,10 @@
 	margin: 0;
 }
 
+#adminmenu a.code-snippets-edit-menu-link {
+	cursor: pointer;
+}
+
 .snippet-description-container {
 	.wp-editor-tools {
 		padding-block-start: 5px;

--- a/src/css/edit.scss
+++ b/src/css/edit.scss
@@ -9,6 +9,7 @@
 @use 'common/select';
 @use 'common/tooltips';
 @use 'common/modal';
+@use 'common/notices';
 @use 'common/upsell';
 @use 'common/toolbar';
 @use 'edit/form';
@@ -104,13 +105,5 @@ form.condition-snippet .snippet-code-container {
 		content: '<';
 		color: #2271b1;
 		margin-inline-end: 3px;
-	}
-}
-
-.code-snippets-notice {
-	details pre {
-		max-inline-size: 100%;
-		overflow: auto hidden;
-		white-space: pre;
 	}
 }

--- a/src/css/edit.scss
+++ b/src/css/edit.scss
@@ -106,3 +106,11 @@ form.condition-snippet .snippet-code-container {
 		margin-inline-end: 3px;
 	}
 }
+
+.code-snippets-notice {
+	details pre {
+		max-inline-size: 100%;
+		overflow: auto hidden;
+		white-space: pre;
+	}
+}

--- a/src/css/edit.scss
+++ b/src/css/edit.scss
@@ -97,13 +97,3 @@
 form.condition-snippet .snippet-code-container {
 	display: none;
 }
-
-.cs-back {
-	cursor: pointer;
-
-	&::before {
-		content: '<';
-		color: #2271b1;
-		margin-inline-end: 3px;
-	}
-}

--- a/src/css/manage.scss
+++ b/src/css/manage.scss
@@ -4,6 +4,7 @@
 @use 'common/tooltips';
 @use 'common/direction';
 @use 'common/select';
+@use 'common/notices';
 @use 'common/upsell';
 @use 'common/toolbar';
 @use 'prism';
@@ -59,10 +60,6 @@
 		align-items: center;
 		gap: 1em;
 	}
-}
-
-.code-snippets-notice a.notice-dismiss {
-	text-decoration: none;
 }
 
 .refresh-button-container {

--- a/src/css/manage/_cloud-community.scss
+++ b/src/css/manage/_cloud-community.scss
@@ -1,6 +1,37 @@
 @use '../common/theme';
 @use '../common/banners';
 
+.cloud-search-form {
+	display: flex;
+	gap: 8px;
+	margin-block: 31px 47px;
+	block-size: 54px;
+
+	> select {
+		flex: 0 0 250px;
+	}
+
+	.button {
+		flex: 0 0 165px;
+	}
+
+	.cloud-search-query {
+		flex: 1;
+		position: relative;
+
+		input {
+			inline-size: 100%;
+			block-size: 100%;
+		}
+
+		> .components-spinner {
+			position: absolute;
+			inset-inline-end: 1.5em;
+			inset-block-start: 25%;
+		}
+	}
+}
+
 .cloud-search {
 	@include banners.banners;
 
@@ -8,23 +39,23 @@
 		justify-content: center;
 	}
 
-  .tablenav.top {
-    display: flex;
-    gap: 20px;
-    block-size: 40px;
-    margin-block-end: 31px;
-    align-items: center;
+	.tablenav.top {
+		display: flex;
+		gap: 20px;
+		block-size: 40px;
+		margin-block-end: 31px;
+		align-items: center;
 
-    select {
-      inline-size: 245px;
-      block-size: 100%;
-    }
+		select {
+			inline-size: 245px;
+			block-size: 100%;
+		}
 
-    .tablenav-pages {
-      margin: 0;
-      margin-inline-start: auto;
-    }
-  }
+		.tablenav-pages {
+			margin: 0;
+			margin-inline-start: auto;
+		}
+	}
 }
 
 .cloud-search-results {
@@ -97,10 +128,6 @@
 		padding-block: 12px;
 		align-items: center;
 
-		.components-spinner {
-			margin: 0;
-		}
-
 		.dashicons-warning {
 			color: #b32d2e;
 		}
@@ -118,33 +145,6 @@
 	}
 }
 
-.cloud-search-form {
-	display: flex;
-	gap: 8px;
-	margin-block: 31px 47px;
-	block-size: 54px;
-
-	select {
-		flex: 0 0 250px;
-	}
-
-	.button {
-		flex: 0 0 165px;
-	}
-
-	.cloud-search-query {
-		flex: 1;
-		position: relative;
-
-		input {
-			inline-size: 100%;
-			block-size: 100%;
-		}
-
-		.components-spinner {
-			position: absolute;
-			inset-inline-end: 1.5em;
-			inset-block-start: 25%;
-		}
-	}
+.cloud-search-results .cloud-search-result footer > .components-spinner {
+	margin: 0;
 }

--- a/src/css/manage/_cloud-community.scss
+++ b/src/css/manage/_cloud-community.scss
@@ -7,6 +7,24 @@
 	.banner {
 		justify-content: center;
 	}
+
+  .tablenav.top {
+    display: flex;
+    gap: 20px;
+    block-size: 40px;
+    margin-block-end: 31px;
+    align-items: center;
+
+    select {
+      inline-size: 245px;
+      block-size: 100%;
+    }
+
+    .tablenav-pages {
+      margin: 0;
+      margin-inline-start: auto;
+    }
+  }
 }
 
 .cloud-search-results {
@@ -128,23 +146,5 @@
 			inset-inline-end: 1.5em;
 			inset-block-start: 25%;
 		}
-	}
-}
-
-.tablenav.top {
-	display: flex;
-	gap: 20px;
-	block-size: 40px;
-	margin-block-end: 31px;
-	align-items: center;
-
-	select {
-		inline-size: 245px;
-		block-size: 100%;
-	}
-
-	.tablenav-pages {
-		margin: 0;
-		margin-inline-start: auto;
 	}
 }

--- a/src/css/manage/_snippets-table.scss
+++ b/src/css/manage/_snippets-table.scss
@@ -178,18 +178,20 @@
 }
 
 .wp-list-table.truncate-row-values {
-	table-layout: fixed;
-
-	td.column-desc {
-		overflow: hidden;
-	}
-
 	#wpbody-content td.column-name > .snippet-name,
 	td.column-desc .snippet-description-content {
 		display: block;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	#wpbody-content td.column-name > .snippet-name {
+		max-inline-size: min(24rem, 30vw);
+	}
+
+	td.column-desc .snippet-description-content {
+		max-inline-size: min(36rem, 45vw);
 	}
 }
 

--- a/src/css/manage/_snippets-table.scss
+++ b/src/css/manage/_snippets-table.scss
@@ -166,7 +166,6 @@
 		min-inline-size: 130px;
 		max-inline-size: 130px;
 		text-align: end;
-		padding-inline: 8px;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
@@ -183,15 +182,14 @@
 		display: block;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		white-space: nowrap;
 	}
 
 	td.column-name > .snippet-name {
-		max-inline-size: min(24rem, 30vw);
+		max-inline-size: min(15rem, 30vw);
 	}
 
 	td.column-desc .snippet-description-content {
-		max-inline-size: min(36rem, 45vw);
+		max-inline-size: min(25rem, 45vw);
 	}
 }
 

--- a/src/css/manage/_snippets-table.scss
+++ b/src/css/manage/_snippets-table.scss
@@ -178,7 +178,7 @@
 }
 
 .wp-list-table.truncate-row-values {
-	#wpbody-content td.column-name > .snippet-name,
+	td.column-name > .snippet-name,
 	td.column-desc .snippet-description-content {
 		display: block;
 		overflow: hidden;
@@ -186,7 +186,7 @@
 		white-space: nowrap;
 	}
 
-	#wpbody-content td.column-name > .snippet-name {
+	td.column-name > .snippet-name {
 		max-inline-size: min(24rem, 30vw);
 	}
 

--- a/src/css/manage/_snippets-table.scss
+++ b/src/css/manage/_snippets-table.scss
@@ -177,6 +177,22 @@
 	}
 }
 
+.wp-list-table.truncate-row-values {
+	table-layout: fixed;
+
+	td.column-desc {
+		overflow: hidden;
+	}
+
+	#wpbody-content td.column-name > .snippet-name,
+	td.column-desc .snippet-description-content {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+}
+
 .wp-core-ui .button.clear-filters {
 	vertical-align: baseline;
 }

--- a/src/css/manage/_snippets-table.scss
+++ b/src/css/manage/_snippets-table.scss
@@ -170,6 +170,11 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
+
+	td.column-date .modified-column-content {
+		display: block;
+		text-align: end;
+	}
 }
 
 .wp-core-ui .button.clear-filters {

--- a/src/css/manage/_snippets-table.scss
+++ b/src/css/manage/_snippets-table.scss
@@ -173,7 +173,7 @@
 
 	td.column-date .modified-column-content {
 		display: block;
-		text-align: end;
+		text-align: start;
 	}
 }
 

--- a/src/js/components/EditMenu/EditMenu.tsx
+++ b/src/js/components/EditMenu/EditMenu.tsx
@@ -8,7 +8,6 @@ interface EditMenuLinkBinding {
 	originalHref: string | null
 	originalRole: string | null
 	originalTabIndex: string | null
-	originalAriaDisabled: string | null
 	handleClick: (event: MouseEvent) => void
 	handleKeyDown: (event: KeyboardEvent) => void
 }
@@ -58,13 +57,11 @@ const bindEditMenuLink = (menuLink: HTMLAnchorElement, page: string): EditMenuLi
 		originalHref: menuLink.getAttribute('href'),
 		originalRole: menuLink.getAttribute('role'),
 		originalTabIndex: menuLink.getAttribute('tabindex'),
-		originalAriaDisabled: menuLink.getAttribute('aria-disabled'),
 		handleClick,
 		handleKeyDown
 	}
 
 	menuLink.dataset.codeSnippetsDisabled = 'true'
-	menuLink.setAttribute('aria-disabled', 'true')
 	menuLink.setAttribute('role', 'button')
 	menuLink.setAttribute('tabindex', '0')
 	menuLink.classList.add('code-snippets-edit-menu-link')
@@ -80,7 +77,6 @@ const unbindEditMenuLink = ({
 	originalHref,
 	originalRole,
 	originalTabIndex,
-	originalAriaDisabled,
 	handleClick,
 	handleKeyDown
 }: EditMenuLinkBinding) => {
@@ -92,7 +88,6 @@ const unbindEditMenuLink = ({
 	restoreAttribute(menuLink, 'href', originalHref)
 	restoreAttribute(menuLink, 'role', originalRole)
 	restoreAttribute(menuLink, 'tabindex', originalTabIndex)
-	restoreAttribute(menuLink, 'aria-disabled', originalAriaDisabled)
 }
 
 const useEditMenuLinkFocus = () => {

--- a/src/js/components/EditMenu/EditMenu.tsx
+++ b/src/js/components/EditMenu/EditMenu.tsx
@@ -1,5 +1,123 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { SnippetForm } from './SnippetForm'
 
-export const EditMenu = () =>
-	<SnippetForm />
+const EVENT_NAME = 'code_snippets_focus_editor'
+
+interface EditMenuLinkBinding {
+	menuLink: HTMLAnchorElement
+	originalHref: string | null
+	originalRole: string | null
+	originalTabIndex: string | null
+	originalAriaDisabled: string | null
+	handleClick: (event: MouseEvent) => void
+	handleKeyDown: (event: KeyboardEvent) => void
+}
+
+const focusCodeEditor = () => {
+	window.dispatchEvent(new CustomEvent(EVENT_NAME))
+}
+
+const restoreAttribute = (menuLink: HTMLAnchorElement, name: string, value: string | null) => {
+	if (value) {
+		menuLink.setAttribute(name, value)
+		return
+	}
+
+	menuLink.removeAttribute(name)
+}
+
+const getEditPage = (): string | null => {
+	const editUrl = window.CODE_SNIPPETS?.urls.edit
+
+	return editUrl ? new URL(editUrl, window.location.origin).searchParams.get('page') : null
+}
+
+const bindEditMenuLink = (menuLink: HTMLAnchorElement, page: string): EditMenuLinkBinding | undefined => {
+	const menuUrl = new URL(menuLink.href, window.location.origin)
+
+	if (page !== menuUrl.searchParams.get('page')) {
+		return undefined
+	}
+
+	const handleClick = (event: MouseEvent) => {
+		event.preventDefault()
+		focusCodeEditor()
+	}
+
+	const handleKeyDown = (event: KeyboardEvent) => {
+		if ('Enter' !== event.key && ' ' !== event.key) {
+			return
+		}
+
+		event.preventDefault()
+		focusCodeEditor()
+	}
+
+	const binding = {
+		menuLink,
+		originalHref: menuLink.getAttribute('href'),
+		originalRole: menuLink.getAttribute('role'),
+		originalTabIndex: menuLink.getAttribute('tabindex'),
+		originalAriaDisabled: menuLink.getAttribute('aria-disabled'),
+		handleClick,
+		handleKeyDown
+	}
+
+	menuLink.dataset.codeSnippetsDisabled = 'true'
+	menuLink.setAttribute('aria-disabled', 'true')
+	menuLink.setAttribute('role', 'button')
+	menuLink.setAttribute('tabindex', '0')
+	menuLink.classList.add('code-snippets-edit-menu-link')
+	menuLink.removeAttribute('href')
+	menuLink.addEventListener('click', handleClick)
+	menuLink.addEventListener('keydown', handleKeyDown)
+
+	return binding
+}
+
+const unbindEditMenuLink = ({
+	menuLink,
+	originalHref,
+	originalRole,
+	originalTabIndex,
+	originalAriaDisabled,
+	handleClick,
+	handleKeyDown
+}: EditMenuLinkBinding) => {
+	menuLink.removeEventListener('click', handleClick)
+	menuLink.removeEventListener('keydown', handleKeyDown)
+	menuLink.classList.remove('code-snippets-edit-menu-link')
+	delete menuLink.dataset.codeSnippetsDisabled
+
+	restoreAttribute(menuLink, 'href', originalHref)
+	restoreAttribute(menuLink, 'role', originalRole)
+	restoreAttribute(menuLink, 'tabindex', originalTabIndex)
+	restoreAttribute(menuLink, 'aria-disabled', originalAriaDisabled)
+}
+
+const useEditMenuLinkFocus = () => {
+	useEffect(() => {
+		const page = getEditPage()
+
+		if (!page) {
+			return
+		}
+
+		const editMenuLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>('#adminmenu a[href]'))
+			.flatMap(menuLink => {
+				const binding = bindEditMenuLink(menuLink, page)
+
+				return binding ? [binding] : []
+			})
+
+		return () => {
+			editMenuLinks.forEach(unbindEditMenuLink)
+		}
+	}, [])
+}
+
+export const EditMenu = () => {
+	useEditMenuLinkFocus()
+
+	return <SnippetForm />
+}

--- a/src/js/components/EditMenu/EditMenu.tsx
+++ b/src/js/components/EditMenu/EditMenu.tsx
@@ -5,9 +5,9 @@ const EVENT_NAME = 'code_snippets_focus_editor'
 
 interface EditMenuLinkBinding {
 	menuLink: HTMLAnchorElement
-	originalHref: string | null
-	originalRole: string | null
-	originalTabIndex: string | null
+	originalHref: string | undefined
+	originalRole: string | undefined
+	originalTabIndex: string | undefined
 	handleClick: (event: MouseEvent) => void
 	handleKeyDown: (event: KeyboardEvent) => void
 }
@@ -16,8 +16,8 @@ const focusCodeEditor = () => {
 	window.dispatchEvent(new CustomEvent(EVENT_NAME))
 }
 
-const restoreAttribute = (menuLink: HTMLAnchorElement, name: string, value: string | null) => {
-	if (value) {
+const restoreAttribute = (menuLink: HTMLAnchorElement, name: string, value: string | undefined) => {
+	if (undefined !== value) {
 		menuLink.setAttribute(name, value)
 		return
 	}
@@ -25,10 +25,10 @@ const restoreAttribute = (menuLink: HTMLAnchorElement, name: string, value: stri
 	menuLink.removeAttribute(name)
 }
 
-const getEditPage = (): string | null => {
+const getEditPage = (): string | undefined => {
 	const editUrl = window.CODE_SNIPPETS?.urls.edit
 
-	return editUrl ? new URL(editUrl, window.location.origin).searchParams.get('page') : null
+	return editUrl ? new URL(editUrl, window.location.origin).searchParams.get('page') ?? undefined : undefined
 }
 
 const bindEditMenuLink = (menuLink: HTMLAnchorElement, page: string): EditMenuLinkBinding | undefined => {
@@ -54,9 +54,9 @@ const bindEditMenuLink = (menuLink: HTMLAnchorElement, page: string): EditMenuLi
 
 	const binding = {
 		menuLink,
-		originalHref: menuLink.getAttribute('href'),
-		originalRole: menuLink.getAttribute('role'),
-		originalTabIndex: menuLink.getAttribute('tabindex'),
+		originalHref: menuLink.getAttribute('href') ?? undefined,
+		originalRole: menuLink.getAttribute('role') ?? undefined,
+		originalTabIndex: menuLink.getAttribute('tabindex') ?? undefined,
 		handleClick,
 		handleKeyDown
 	}

--- a/src/js/components/EditMenu/EditorSidebar/EditorSidebar.tsx
+++ b/src/js/components/EditMenu/EditorSidebar/EditorSidebar.tsx
@@ -64,7 +64,7 @@ export const EditorSidebar: React.FC<EditorSidebarProps> = ({ setIsUpgradeDialog
 				{isWorking ? <Spinner /> : ''}
 			</p>
 
-			<Notices />
+			<Notices placement="sidebar" />
 		</div>
 	)
 }

--- a/src/js/components/EditMenu/SnippetForm/SnippetForm.tsx
+++ b/src/js/components/EditMenu/SnippetForm/SnippetForm.tsx
@@ -19,6 +19,7 @@ import { TagsEditor } from './fields/TagsEditor'
 import { CodeEditor } from './fields/CodeEditor'
 import { DescriptionEditor } from './fields/DescriptionEditor'
 import { NameInput } from './fields/NameInput'
+import { Notices } from './page/Notices'
 import { PageHeading } from './page/PageHeading'
 import type { PropsWithChildren } from 'react'
 import type { Snippet } from '../../../types/Snippet'
@@ -158,6 +159,7 @@ const EditFormWrap: React.FC = () => {
 			</small></p>
 
 			<PageHeading />
+			<Notices placement="above-form" />
 
 			<EditForm className={editFormClassName({ snippet, isReadOnly, isExpanded })}>
 				<main className="snippet-form-upper">

--- a/src/js/components/EditMenu/SnippetForm/SnippetForm.tsx
+++ b/src/js/components/EditMenu/SnippetForm/SnippetForm.tsx
@@ -148,16 +148,6 @@ const EditFormWrap: React.FC = () => {
 
 	return (
 		<div className="wrap">
-			<p><small className="cs-back">
-				{isCondition(snippet)
-					? <a href={buildUrl(window.CODE_SNIPPETS?.urls.manage, { type: 'cond' })}>
-						{__('Back to all conditions', 'code-snippets')}
-					</a>
-					: <a href={window.CODE_SNIPPETS?.urls.manage}>
-						{__('Back to all snippets', 'code-snippets')}
-					</a>}
-			</small></p>
-
 			<PageHeading />
 			<Notices placement="above-form" />
 

--- a/src/js/components/EditMenu/SnippetForm/fields/CodeEditor.tsx
+++ b/src/js/components/EditMenu/SnippetForm/fields/CodeEditor.tsx
@@ -14,6 +14,28 @@ interface EditorTextareaProps {
 	textareaRef: RefObject<HTMLTextAreaElement>
 }
 
+const useFocusEditorShortcut = (
+	codeEditorInstance: ReturnType<typeof useSnippetForm>['codeEditorInstance'],
+	textareaRef: RefObject<HTMLTextAreaElement>
+) => {
+	useEffect(() => {
+		const focusEditor = () => {
+			if (codeEditorInstance) {
+				codeEditorInstance.codemirror.focus()
+				return
+			}
+
+			textareaRef.current?.focus()
+		}
+
+		window.addEventListener('code_snippets_focus_editor', focusEditor)
+
+		return () => {
+			window.removeEventListener('code_snippets_focus_editor', focusEditor)
+		}
+	}, [codeEditorInstance, textareaRef])
+}
+
 const EditorTextarea: React.FC<EditorTextareaProps> = ({ textareaRef }) => {
 	const { snippet, setSnippet } = useSnippetForm()
 
@@ -76,6 +98,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({ isExpanded, setIsExpande
 			})
 		}
 	}, [submitSnippet, codeEditorInstance, snippet])
+
+	useFocusEditorShortcut(codeEditorInstance, textareaRef)
 
 	return (
 		<div className="snippet-code-container">

--- a/src/js/components/EditMenu/SnippetForm/fields/CodeEditor.tsx
+++ b/src/js/components/EditMenu/SnippetForm/fields/CodeEditor.tsx
@@ -15,9 +15,10 @@ interface EditorTextareaProps {
 }
 
 const useFocusEditorShortcut = (
-	codeEditorInstance: ReturnType<typeof useSnippetForm>['codeEditorInstance'],
 	textareaRef: RefObject<HTMLTextAreaElement>
 ) => {
+	const { codeEditorInstance } = useSnippetForm()
+
 	useEffect(() => {
 		const focusEditor = () => {
 			if (codeEditorInstance) {
@@ -99,7 +100,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({ isExpanded, setIsExpande
 		}
 	}, [submitSnippet, codeEditorInstance, snippet])
 
-	useFocusEditorShortcut(codeEditorInstance, textareaRef)
+	useFocusEditorShortcut(textareaRef)
 
 	return (
 		<div className="snippet-code-container">

--- a/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
+++ b/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
@@ -15,11 +15,11 @@ interface NoticesProps {
 export const Notices: React.FC<NoticesProps> = ({ placement }) => {
 	const { currentNotice, setCurrentNotice, snippet, setSnippet } = useSnippetForm()
 	const showCurrentNotice = 'above-form' === placement ? hasStackTrace(currentNotice) : !hasStackTrace(currentNotice)
-	const showCodeErrorNotice = 'sidebar' === placement
+	const showCodeErrorNotice = 'sidebar' === placement && !snippet.code_error_trace
 
 	return <>
 		{showCurrentNotice && currentNotice
-			? <DismissibleNotice className={currentNotice[0]} onDismiss={() => setCurrentNotice(undefined)}>
+			? <DismissibleNotice className={`${currentNotice[0]} code-snippets-notice`} onDismiss={() => setCurrentNotice(undefined)}>
 				<p>{createInterpolateElement(currentNotice[1], { strong: <strong /> })}</p>
 				{currentNotice[DESCRIPTION_INDEX]
 					? <p>{createInterpolateElement(currentNotice[DESCRIPTION_INDEX], { strong: <strong /> })}</p>

--- a/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
+++ b/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
@@ -3,10 +3,15 @@ import React, { useEffect, useRef, useState } from 'react'
 import { __, sprintf } from '@wordpress/i18n'
 import { useSnippetForm } from '../WithSnippetFormContext'
 import { DismissibleNotice } from '../../../common/Notice'
+import type { ReactNode } from 'react'
 
 const DESCRIPTION_INDEX = 2
 const DETAILS_INDEX = 3
 const hasStackTrace = (notice?: readonly unknown[]): boolean => Boolean(notice?.[DETAILS_INDEX])
+const renderNoticeLine = (line: ReactNode): ReactNode =>
+	'string' === typeof line
+		? createInterpolateElement(line, { strong: <strong /> })
+		: line
 
 interface NoticesProps {
 	placement: 'above-form' | 'sidebar'
@@ -57,9 +62,9 @@ export const Notices: React.FC<NoticesProps> = ({ placement }) => {
 	return <>
 		{showCurrentNotice && currentNotice
 			? <DismissibleNotice className={`${currentNotice[0]} code-snippets-notice`} onDismiss={() => setCurrentNotice(undefined)}>
-				<p>{createInterpolateElement(currentNotice[1], { strong: <strong /> })}</p>
+				<p>{renderNoticeLine(currentNotice[1])}</p>
 				{currentNotice[DESCRIPTION_INDEX]
-					? <p>{createInterpolateElement(currentNotice[DESCRIPTION_INDEX], { strong: <strong /> })}</p>
+					? <p>{renderNoticeLine(currentNotice[DESCRIPTION_INDEX])}</p>
 					: null}
 				{currentNotice[DETAILS_INDEX]
 					? <StackTraceDetails trace={currentNotice[DETAILS_INDEX]} />

--- a/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
+++ b/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
@@ -1,5 +1,5 @@
 import { createInterpolateElement } from '@wordpress/element'
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { __, sprintf } from '@wordpress/i18n'
 import { useSnippetForm } from '../WithSnippetFormContext'
 import { DismissibleNotice } from '../../../common/Notice'
@@ -10,6 +10,43 @@ const hasStackTrace = (notice?: readonly unknown[]): boolean => Boolean(notice?.
 
 interface NoticesProps {
 	placement: 'above-form' | 'sidebar'
+}
+
+const StackTraceDetails: React.FC<{ trace: string }> = ({ trace }) => {
+	const preRef = useRef<HTMLPreElement>(null)
+	const [isOpen, setIsOpen] = useState(false)
+	const [showHint, setShowHint] = useState(false)
+
+	useEffect(() => {
+		if (!isOpen) {
+			setShowHint(false)
+			return
+		}
+
+		const updateHintVisibility = () => {
+			const pre = preRef.current
+			setShowHint(Boolean(pre && pre.scrollWidth > pre.clientWidth))
+		}
+
+		updateHintVisibility()
+		window.addEventListener('resize', updateHintVisibility)
+
+		return () => {
+			window.removeEventListener('resize', updateHintVisibility)
+		}
+	}, [isOpen, trace])
+
+	return (
+		<details onToggle={event => setIsOpen(event.currentTarget.open)}>
+			<summary>{__('View stack trace', 'code-snippets')}</summary>
+			<pre ref={preRef}>{trace}</pre>
+			{showHint
+				? <p className="stack-trace-hint">
+					<em>{__('Scroll horizontally if the trace is cut off.', 'code-snippets')}</em>
+				</p>
+				: null}
+		</details>
+	)
 }
 
 export const Notices: React.FC<NoticesProps> = ({ placement }) => {
@@ -25,13 +62,7 @@ export const Notices: React.FC<NoticesProps> = ({ placement }) => {
 					? <p>{createInterpolateElement(currentNotice[DESCRIPTION_INDEX], { strong: <strong /> })}</p>
 					: null}
 				{currentNotice[DETAILS_INDEX]
-					? <details>
-						<summary>{__('View stack trace', 'code-snippets')}</summary>
-						<pre>{currentNotice[DETAILS_INDEX]}</pre>
-						<p className="stack-trace-hint">
-							<em>{__('Scroll horizontally if the trace is cut off.', 'code-snippets')}</em>
-						</p>
-					</details>
+					? <StackTraceDetails trace={currentNotice[DETAILS_INDEX]} />
 					: null}
 			</DismissibleNotice>
 			: null}

--- a/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
+++ b/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
@@ -6,12 +6,19 @@ import { DismissibleNotice } from '../../../common/Notice'
 
 const DESCRIPTION_INDEX = 2
 const DETAILS_INDEX = 3
+const hasStackTrace = (notice?: readonly unknown[]): boolean => Boolean(notice?.[DETAILS_INDEX])
 
-export const Notices: React.FC = () => {
+interface NoticesProps {
+	placement: 'above-form' | 'sidebar'
+}
+
+export const Notices: React.FC<NoticesProps> = ({ placement }) => {
 	const { currentNotice, setCurrentNotice, snippet, setSnippet } = useSnippetForm()
+	const showCurrentNotice = 'above-form' === placement ? hasStackTrace(currentNotice) : !hasStackTrace(currentNotice)
+	const showCodeErrorNotice = 'sidebar' === placement
 
 	return <>
-		{currentNotice
+		{showCurrentNotice && currentNotice
 			? <DismissibleNotice className={currentNotice[0]} onDismiss={() => setCurrentNotice(undefined)}>
 				<p>{createInterpolateElement(currentNotice[1], { strong: <strong /> })}</p>
 				{currentNotice[DESCRIPTION_INDEX]
@@ -26,7 +33,7 @@ export const Notices: React.FC = () => {
 			</DismissibleNotice>
 			: null}
 
-		{!currentNotice && snippet.code_error
+		{showCodeErrorNotice && !currentNotice && snippet.code_error
 			? <DismissibleNotice
 				className="notice-error"
 				onDismiss={() => setSnippet(previous => ({ ...previous, code_error: null, code_error_trace: null }))}

--- a/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
+++ b/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
@@ -4,6 +4,9 @@ import { __, sprintf } from '@wordpress/i18n'
 import { useSnippetForm } from '../WithSnippetFormContext'
 import { DismissibleNotice } from '../../../common/Notice'
 
+const DESCRIPTION_INDEX = 2
+const DETAILS_INDEX = 3
+
 export const Notices: React.FC = () => {
 	const { currentNotice, setCurrentNotice, snippet, setSnippet } = useSnippetForm()
 
@@ -11,13 +14,22 @@ export const Notices: React.FC = () => {
 		{currentNotice
 			? <DismissibleNotice className={currentNotice[0]} onDismiss={() => setCurrentNotice(undefined)}>
 				<p>{createInterpolateElement(currentNotice[1], { strong: <strong /> })}</p>
+				{currentNotice[DESCRIPTION_INDEX]
+					? <p>{createInterpolateElement(currentNotice[DESCRIPTION_INDEX], { strong: <strong /> })}</p>
+					: null}
+				{currentNotice[DETAILS_INDEX]
+					? <details>
+						<summary>{__('View stack trace', 'code-snippets')}</summary>
+						<pre>{currentNotice[DETAILS_INDEX]}</pre>
+					</details>
+					: null}
 			</DismissibleNotice>
 			: null}
 
-		{snippet.code_error
+		{!currentNotice && snippet.code_error
 			? <DismissibleNotice
 				className="notice-error"
-				onDismiss={() => setSnippet(previous => ({ ...previous, code_error: null }))}
+				onDismiss={() => setSnippet(previous => ({ ...previous, code_error: null, code_error_trace: null }))}
 			>
 				<p>
 					<strong>{sprintf(

--- a/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
+++ b/src/js/components/EditMenu/SnippetForm/page/Notices.tsx
@@ -28,6 +28,9 @@ export const Notices: React.FC<NoticesProps> = ({ placement }) => {
 					? <details>
 						<summary>{__('View stack trace', 'code-snippets')}</summary>
 						<pre>{currentNotice[DETAILS_INDEX]}</pre>
+						<p className="stack-trace-hint">
+							<em>{__('Scroll horizontally if the trace is cut off.', 'code-snippets')}</em>
+						</p>
 					</details>
 					: null}
 			</DismissibleNotice>

--- a/src/js/components/ManageMenu/CommunityCloud/WithCloudSearchContext.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/WithCloudSearchContext.tsx
@@ -9,6 +9,7 @@ import type { CloudSnippetSchema } from '../../../types/schema/CloudSnippetSchem
 const SEARCH_PARAM = 's'
 const SEARCH_METHOD_PARAM = 'by'
 const DEFAULT_SNIPPETS_PER_PAGE = 10
+const MAX_CLOUD_RESULTS_PER_PAGE = 100
 
 export interface CloudSearchContext {
 	page: number
@@ -32,7 +33,10 @@ export const WithCloudSearchContext: React.FC<PropsWithChildren> = ({ children }
 	const [page, setPage] = useState(1)
 	const [query, setQuery] = useState(() => fetchQueryParam(SEARCH_PARAM) ?? '')
 	const [searchByCodevault, setSearchByCodevault] = useState(() => 'codevault' === fetchQueryParam(SEARCH_METHOD_PARAM))
-	const snippetsPerPage = window.CODE_SNIPPETS_MANAGE?.snippetsPerPage ?? DEFAULT_SNIPPETS_PER_PAGE
+	const snippetsPerPage = Math.min(
+		window.CODE_SNIPPETS_MANAGE?.snippetsPerPage ?? DEFAULT_SNIPPETS_PER_PAGE,
+		MAX_CLOUD_RESULTS_PER_PAGE
+	)
 
 	const [totalItems, setTotalItems] = useState(0)
 	const [totalPages, setTotalPages] = useState(0)

--- a/src/js/components/ManageMenu/CommunityCloud/WithCloudSearchContext.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/WithCloudSearchContext.tsx
@@ -55,14 +55,12 @@ export const WithCloudSearchContext: React.FC<PropsWithChildren> = ({ children }
 				buildUrl(REST_BASES.cloud, { query, searchByCodevault, page, per_page: snippetsPerPage })
 			)
 				.then(response => {
-					console.log(response.headers)
 					setTotalItems(Number(response.headers['x-wp-total']))
 					setTotalPages(Number(response.headers['x-wp-totalpages']))
 					setSearchResults(response.data)
 					setIsSearching(false)
 				})
-				.catch((error: unknown) => {
-					console.error(error)
+				.catch(() => {
 					setIsSearching(false)
 					setError(true)
 				})

--- a/src/js/components/ManageMenu/CommunityCloud/WithCloudSearchContext.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/WithCloudSearchContext.tsx
@@ -8,6 +8,7 @@ import type { CloudSnippetSchema } from '../../../types/schema/CloudSnippetSchem
 
 const SEARCH_PARAM = 's'
 const SEARCH_METHOD_PARAM = 'by'
+const DEFAULT_SNIPPETS_PER_PAGE = 10
 
 export interface CloudSearchContext {
 	page: number
@@ -31,6 +32,7 @@ export const WithCloudSearchContext: React.FC<PropsWithChildren> = ({ children }
 	const [page, setPage] = useState(1)
 	const [query, setQuery] = useState(() => fetchQueryParam(SEARCH_PARAM) ?? '')
 	const [searchByCodevault, setSearchByCodevault] = useState(() => 'codevault' === fetchQueryParam(SEARCH_METHOD_PARAM))
+	const snippetsPerPage = window.CODE_SNIPPETS_MANAGE?.snippetsPerPage ?? DEFAULT_SNIPPETS_PER_PAGE
 
 	const [totalItems, setTotalItems] = useState(0)
 	const [totalPages, setTotalPages] = useState(0)
@@ -45,7 +47,9 @@ export const WithCloudSearchContext: React.FC<PropsWithChildren> = ({ children }
 			updateQueryParam(SEARCH_METHOD_PARAM, searchByCodevault ? 'codevault' : 'term')
 			setIsSearching(true)
 
-			api.getResponse<CloudSnippetSchema[]>(buildUrl(REST_BASES.cloud, { query, searchByCodevault, page }))
+			api.getResponse<CloudSnippetSchema[]>(
+				buildUrl(REST_BASES.cloud, { query, searchByCodevault, page, per_page: snippetsPerPage })
+			)
 				.then(response => {
 					console.log(response.headers)
 					setTotalItems(Number(response.headers['x-wp-total']))
@@ -59,7 +63,7 @@ export const WithCloudSearchContext: React.FC<PropsWithChildren> = ({ children }
 					setError(true)
 				})
 		}
-	}, [api, page, query, searchByCodevault])
+	}, [api, page, query, searchByCodevault, snippetsPerPage])
 
 	const value: CloudSearchContext = {
 		page,

--- a/src/js/components/ManageMenu/CommunityCloud/WithCloudSearchContext.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/WithCloudSearchContext.tsx
@@ -34,7 +34,7 @@ export const WithCloudSearchContext: React.FC<PropsWithChildren> = ({ children }
 	const [query, setQuery] = useState(() => fetchQueryParam(SEARCH_PARAM) ?? '')
 	const [searchByCodevault, setSearchByCodevault] = useState(() => 'codevault' === fetchQueryParam(SEARCH_METHOD_PARAM))
 	const snippetsPerPage = Math.min(
-		window.CODE_SNIPPETS_MANAGE?.snippetsPerPage ?? DEFAULT_SNIPPETS_PER_PAGE,
+		window.CODE_SNIPPETS_MANAGE?.cloudSearchPerPage ?? window.CODE_SNIPPETS_MANAGE?.snippetsPerPage ?? DEFAULT_SNIPPETS_PER_PAGE,
 		MAX_CLOUD_RESULTS_PER_PAGE
 	)
 

--- a/src/js/components/ManageMenu/ManageMenu.tsx
+++ b/src/js/components/ManageMenu/ManageMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { fetchQueryParam } from '../../utils/urls'
 import { Toolbar } from '../common/Toolbar'
 import { CommunityCloud } from './CommunityCloud/CommunityCloud'
@@ -6,6 +6,22 @@ import { SnippetsTable } from './SnippetsTable'
 
 export const ManageMenu = () => {
 	const subpage = useMemo(() => fetchQueryParam('subpage'), [])
+
+	useEffect(() => {
+		if ('cloud-community' === subpage) {
+			return
+		}
+
+		const screenOptionsForm = document.getElementById('adv-settings')
+		const tableOptions = screenOptionsForm?.querySelector<HTMLFieldSetElement>('fieldset.table-options-prefs')
+		const columns = Array.from(
+			screenOptionsForm?.querySelectorAll<HTMLFieldSetElement>('fieldset.metabox-prefs') ?? []
+		).find(fieldset => !fieldset.classList.contains('table-options-prefs'))
+
+		if (screenOptionsForm && tableOptions && columns) {
+			screenOptionsForm.insertBefore(tableOptions, columns)
+		}
+	}, [subpage])
 
 	return (
 		<>

--- a/src/js/components/ManageMenu/ManageMenu.tsx
+++ b/src/js/components/ManageMenu/ManageMenu.tsx
@@ -14,6 +14,10 @@ export const ManageMenu = () => {
 
 		const screenOptionsForm = document.getElementById('adv-settings')
 		const tableOptions = screenOptionsForm?.querySelector<HTMLFieldSetElement>('fieldset.table-options-prefs')
+		// Locate the first column-visibility fieldset that is NOT the table-options one.
+		// This relies on WordPress core rendering #adv-settings with .metabox-prefs fieldsets.
+		// Verified against WP 6.5+ (core/Screen_Options). If WP changes this structure the
+		// reordering will silently no-op, which is acceptable — it is a cosmetic improvement only.
 		const columns = Array.from(
 			screenOptionsForm?.querySelectorAll<HTMLFieldSetElement>('fieldset.metabox-prefs') ?? []
 		).find(fieldset => !fieldset.classList.contains('table-options-prefs'))

--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -1,5 +1,6 @@
 import { __, _x, sprintf } from '@wordpress/i18n'
 import React, { Fragment, useEffect, useMemo, useState } from 'react'
+import classnames from 'classnames'
 import { createInterpolateElement } from '@wordpress/element'
 import { useRestAPI } from '../../../hooks/useRestAPI'
 import { useSnippetsList } from '../../../hooks/useSnippetsList'
@@ -86,8 +87,11 @@ interface ExtraTableNavProps {
 	visibleSnippets: Snippet[]
 }
 
-const useHiddenColumns = (): string[] => {
+const useManageTableSettings = (): { hiddenColumns: string[], truncateRowValues: boolean } => {
 	const [hiddenColumns, setHiddenColumns] = useState<string[]>(() => window.CODE_SNIPPETS_MANAGE?.hiddenColumns ?? [])
+	const [truncateRowValues, setTruncateRowValues] = useState(
+		() => 0 !== Number(window.CODE_SNIPPETS_MANAGE?.truncateRowValues ?? 1)
+	)
 
 	useEffect(() => {
 		const screenOptions = document.getElementById('adv-settings')
@@ -101,6 +105,10 @@ const useHiddenColumns = (): string[] => {
 				Array.from(screenOptions.querySelectorAll<HTMLInputElement>('.hide-column-tog:not(:checked)'))
 					.map(toggle => toggle.value)
 			)
+
+			setTruncateRowValues(
+				screenOptions.querySelector<HTMLInputElement>('#snippets-table-truncate-row-values')?.checked ?? true
+			)
 		}
 
 		updateHiddenColumns()
@@ -111,7 +119,7 @@ const useHiddenColumns = (): string[] => {
 		}
 	}, [])
 
-	return hiddenColumns
+	return { hiddenColumns, truncateRowValues }
 }
 
 const FilterByTagControl: React.FC<ExtraTableNavProps> = ({ visibleSnippets }) => {
@@ -214,7 +222,7 @@ export const SnippetsListTable: React.FC = () => {
 	const { currentStatus, setCurrentStatus } = useSnippetsFilters()
 	const { snippetsByStatus } = useFilteredSnippets()
 
-	const hiddenColumns = useHiddenColumns()
+	const { hiddenColumns, truncateRowValues } = useManageTableSettings()
 	const allSnippets = useMemo(() => snippetsByStatus.get('all') ?? [], [snippetsByStatus])
 	const totalItems = snippetsByStatus.get(currentStatus)?.length ?? 0
 	const itemsPerPage = window.CODE_SNIPPETS_MANAGE?.snippetsPerPage
@@ -235,6 +243,7 @@ export const SnippetsListTable: React.FC = () => {
 			<ListTable
 				items={snippetsByStatus.get(currentStatus) ?? []}
 				getKey={snippet => snippet.id}
+				className={classnames({ 'truncate-row-values': truncateRowValues })}
 				columns={columns}
 				actions={actions}
 				totalPages={itemsPerPage && Math.ceil(totalItems / itemsPerPage)}

--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -1,5 +1,5 @@
 import { __, _x, sprintf } from '@wordpress/i18n'
-import React, { Fragment, useEffect, useMemo } from 'react'
+import React, { Fragment, useEffect, useMemo, useState } from 'react'
 import { createInterpolateElement } from '@wordpress/element'
 import { useRestAPI } from '../../../hooks/useRestAPI'
 import { useSnippetsList } from '../../../hooks/useSnippetsList'
@@ -12,7 +12,7 @@ import { ListTable } from '../../common/ListTable'
 import { SubmitButton } from '../../common/SubmitButton'
 import { INDEX_STATUS, useSnippetsFilters } from './WithSnippetsTableFilters'
 import { useFilteredSnippets } from './WithFilteredSnippetsContext'
-import { TableColumns } from './TableColumns'
+import { getTableColumns } from './TableColumns'
 import type { SnippetStatus} from './WithSnippetsTableFilters'
 import type { ListTableBulkAction } from '../../common/ListTable'
 import type { Snippet } from '../../../types/Snippet'
@@ -86,6 +86,34 @@ interface ExtraTableNavProps {
 	visibleSnippets: Snippet[]
 }
 
+const useHiddenColumns = (): string[] => {
+	const [hiddenColumns, setHiddenColumns] = useState<string[]>(() => window.CODE_SNIPPETS_MANAGE?.hiddenColumns ?? [])
+
+	useEffect(() => {
+		const screenOptions = document.getElementById('adv-settings')
+
+		if (!screenOptions) {
+			return
+		}
+
+		const updateHiddenColumns = () => {
+			setHiddenColumns(
+				Array.from(screenOptions.querySelectorAll<HTMLInputElement>('.hide-column-tog:not(:checked)'))
+					.map(toggle => toggle.value)
+			)
+		}
+
+		updateHiddenColumns()
+		screenOptions.addEventListener('change', updateHiddenColumns)
+
+		return () => {
+			screenOptions.removeEventListener('change', updateHiddenColumns)
+		}
+	}, [])
+
+	return hiddenColumns
+}
+
 const FilterByTagControl: React.FC<ExtraTableNavProps> = ({ visibleSnippets }) => {
 	const { currentTag, setCurrentTag } = useSnippetsFilters()
 
@@ -146,14 +174,8 @@ const NoItemsMessage = () => {
 		</>
 }
 
-export const SnippetsListTable: React.FC = () => {
-	const { currentStatus, setCurrentStatus } = useSnippetsFilters()
-	const { snippetsByStatus } = useFilteredSnippets()
-
-	const allSnippets = useMemo(() => snippetsByStatus.get('all') ?? [], [snippetsByStatus])
-	const totalItems = snippetsByStatus.get(currentStatus)?.length ?? 0
-	const itemsPerPage = window.CODE_SNIPPETS_MANAGE?.snippetsPerPage
-	const actions: ListTableBulkAction<Snippet['id']>[] = useMemo(
+const useBulkActions = (allSnippets: Snippet[]): ListTableBulkAction<Snippet['id']>[] =>
+	useMemo(
 		() => [
 			{
 				name: __('Activate', 'code-snippets'),
@@ -188,6 +210,17 @@ export const SnippetsListTable: React.FC = () => {
 		[allSnippets]
 	)
 
+export const SnippetsListTable: React.FC = () => {
+	const { currentStatus, setCurrentStatus } = useSnippetsFilters()
+	const { snippetsByStatus } = useFilteredSnippets()
+
+	const hiddenColumns = useHiddenColumns()
+	const allSnippets = useMemo(() => snippetsByStatus.get('all') ?? [], [snippetsByStatus])
+	const totalItems = snippetsByStatus.get(currentStatus)?.length ?? 0
+	const itemsPerPage = window.CODE_SNIPPETS_MANAGE?.snippetsPerPage
+	const columns = useMemo(() => getTableColumns(hiddenColumns), [hiddenColumns])
+	const actions = useBulkActions(allSnippets)
+
 	useEffect(() => {
 		if (INDEX_STATUS !== currentStatus && !snippetsByStatus.has(currentStatus)) {
 			setCurrentStatus(INDEX_STATUS)
@@ -202,7 +235,7 @@ export const SnippetsListTable: React.FC = () => {
 			<ListTable
 				items={snippetsByStatus.get(currentStatus) ?? []}
 				getKey={snippet => snippet.id}
-				columns={TableColumns}
+				columns={columns}
 				actions={actions}
 				totalPages={itemsPerPage && Math.ceil(totalItems / itemsPerPage)}
 				extraTableNav={which =>

--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -3,10 +3,9 @@ import React, { Fragment, useEffect, useMemo, useState } from 'react'
 import classnames from 'classnames'
 import { createInterpolateElement } from '@wordpress/element'
 import { useRestAPI } from '../../../hooks/useRestAPI'
-import { useSnippetsAPI } from '../../../hooks/useSnippetsAPI'
 import { useSnippetsList } from '../../../hooks/useSnippetsList'
 import { handleUnknownError } from '../../../utils/errors'
-import { downloadAsFile, downloadBulkSnippetExportFile, downloadSnippetExportFile } from '../../../utils/files'
+import { downloadBulkSnippetExportFile } from '../../../utils/files'
 import { REST_BASES } from '../../../utils/restAPI'
 import { getSnippetType } from '../../../utils/snippets/snippets'
 import { buildUrl } from '../../../utils/urls'
@@ -30,51 +29,76 @@ const STATUS_LABELS: [SnippetStatus, string][] = [
 ]
 
 const BULK_DOWNLOAD_ACTION = 'bulk-download'
-const BULK_DOWNLOAD_FILENAME = 'snippets.code-snippets.zip'
+const BULK_DOWNLOAD_FRAME_NAME = 'code-snippets-bulk-download-frame'
+const INDIVIDUAL_DOWNLOAD_DELAY_MS = 200
 
-const downloadSnippetFilesIndividually = (
-	snippets: readonly Snippet[],
-	exportCode: (snippet: Pick<Snippet, 'id' | 'network'>) => Promise<string>
-) =>
+const getBulkDownloadFrame = (): HTMLIFrameElement => {
+	const existingFrame = document.getElementById(BULK_DOWNLOAD_FRAME_NAME)
+
+	if (existingFrame instanceof HTMLIFrameElement) {
+		return existingFrame
+	}
+
+	const frame = document.createElement('iframe')
+	frame.id = BULK_DOWNLOAD_FRAME_NAME
+	frame.name = BULK_DOWNLOAD_FRAME_NAME
+	frame.hidden = true
+	document.body.appendChild(frame)
+
+	return frame
+}
+
+const appendHiddenField = (form: HTMLFormElement, name: string, value: string) => {
+	const input = document.createElement('input')
+	input.type = 'hidden'
+	input.name = name
+	input.value = value
+	form.appendChild(input)
+}
+
+const submitBulkSnippetDownload = (snippets: readonly Snippet[]): Promise<void> => {
+	if (0 === snippets.length) {
+		return Promise.resolve()
+	}
+
+	const frame = getBulkDownloadFrame()
+	const form = document.createElement('form')
+
+	form.method = 'post'
+	form.action = window.location.href
+	form.target = frame.name
+	form.hidden = true
+
+	appendHiddenField(form, 'code_snippets_action', BULK_DOWNLOAD_ACTION)
+	appendHiddenField(form, 'code_snippets_bulk_download_nonce', window.CODE_SNIPPETS_MANAGE?.bulkDownloadNonce ?? '')
+	appendHiddenField(
+		form,
+		'snippets',
+		JSON.stringify(snippets.map(({ id, network }) => ({ id, network })))
+	)
+
+	document.body.appendChild(form)
+	form.submit()
+
+	window.setTimeout(() => {
+		form.remove()
+	}, 0)
+
+	return Promise.resolve()
+}
+
+const submitBulkSnippetDownloadsIndividually = (snippets: readonly Snippet[]): Promise<void> =>
 	snippets.reduce(
 		(promise, snippet) =>
-			promise.then(() =>
-				exportCode(snippet)
-					.then(response => downloadSnippetExportFile(response, snippet))
+			promise.then(
+				() =>
+					new Promise<void>(resolve => {
+						void submitBulkSnippetDownload([snippet])
+						window.setTimeout(resolve, INDIVIDUAL_DOWNLOAD_DELAY_MS)
+					})
 			),
 		Promise.resolve()
 	)
-
-const downloadBulkSnippetArchive = async (snippets: readonly Snippet[]): Promise<void> => {
-	const body = new URLSearchParams({
-		code_snippets_action: BULK_DOWNLOAD_ACTION,
-		code_snippets_bulk_download_nonce: window.CODE_SNIPPETS_MANAGE?.bulkDownloadNonce ?? '',
-		snippets: JSON.stringify(
-			snippets.map(({ id, network }) => ({ id, network }))
-		)
-	})
-
-	const response = await fetch(window.location.href, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-		},
-		body: body.toString(),
-		credentials: 'same-origin'
-	})
-
-	if (!response.ok) {
-		throw new Error(await response.text())
-	}
-
-	const blob = await response.blob()
-	const filename = response.headers.get('X-Suggested-Filename') ?? BULK_DOWNLOAD_FILENAME
-	const mimeType = '' === blob.type
-		? response.headers.get('Content-Type') ?? 'application/zip'
-		: blob.type
-
-	downloadAsFile(blob, filename, mimeType)
-}
 
 const SnippetStatusCounts = () => {
 	const { currentStatus, setCurrentStatus } = useSnippetsFilters()
@@ -232,8 +256,6 @@ const NoItemsMessage = () => {
 
 const useBulkActions = (allSnippets: Snippet[]): ListTableBulkAction<Snippet['id']>[] =>
 {
-	const api = useSnippetsAPI()
-
 	return useMemo(
 		() => [
 			{
@@ -262,15 +284,11 @@ const useBulkActions = (allSnippets: Snippet[]): ListTableBulkAction<Snippet['id
 				apply: (selected: Set<Snippet['id']>) => {
 					const selectedSnippets = allSnippets.filter(snippet => selected.has(snippet.id))
 
-					if (0 === selectedSnippets.length) {
-						return Promise.resolve()
+					if (1 < selectedSnippets.length && !window.CODE_SNIPPETS_MANAGE?.supportsZipDownloads) {
+						return submitBulkSnippetDownloadsIndividually(selectedSnippets)
 					}
 
-					if (1 === selectedSnippets.length || !window.CODE_SNIPPETS_MANAGE?.supportsZipDownloads) {
-						return downloadSnippetFilesIndividually(selectedSnippets, api.exportCode)
-					}
-
-					return downloadBulkSnippetArchive(selectedSnippets)
+					return submitBulkSnippetDownload(selectedSnippets)
 				}
 			},
 			{
@@ -278,7 +296,7 @@ const useBulkActions = (allSnippets: Snippet[]): ListTableBulkAction<Snippet['id
 				apply: () => Promise.resolve()
 			}
 		],
-		[allSnippets, api.exportCode]
+		[allSnippets]
 	)
 }
 

--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -3,9 +3,10 @@ import React, { Fragment, useEffect, useMemo, useState } from 'react'
 import classnames from 'classnames'
 import { createInterpolateElement } from '@wordpress/element'
 import { useRestAPI } from '../../../hooks/useRestAPI'
+import { useSnippetsAPI } from '../../../hooks/useSnippetsAPI'
 import { useSnippetsList } from '../../../hooks/useSnippetsList'
 import { handleUnknownError } from '../../../utils/errors'
-import { downloadBulkSnippetExportFile } from '../../../utils/files'
+import { downloadAsFile, downloadBulkSnippetExportFile, downloadSnippetExportFile } from '../../../utils/files'
 import { REST_BASES } from '../../../utils/restAPI'
 import { getSnippetType } from '../../../utils/snippets/snippets'
 import { buildUrl } from '../../../utils/urls'
@@ -27,6 +28,53 @@ const STATUS_LABELS: [SnippetStatus, string][] = [
 	['unlocked', __('Unlocked', 'code-snippets')],
 	['trashed', __('Trashed', 'code-snippets')]
 ]
+
+const BULK_DOWNLOAD_ACTION = 'bulk-download'
+const BULK_DOWNLOAD_FILENAME = 'snippets.code-snippets.zip'
+
+const downloadSnippetFilesIndividually = (
+	snippets: readonly Snippet[],
+	exportCode: (snippet: Pick<Snippet, 'id' | 'network'>) => Promise<string>
+) =>
+	snippets.reduce(
+		(promise, snippet) =>
+			promise.then(() =>
+				exportCode(snippet)
+					.then(response => downloadSnippetExportFile(response, snippet))
+			),
+		Promise.resolve()
+	)
+
+const downloadBulkSnippetArchive = async (snippets: readonly Snippet[]): Promise<void> => {
+	const body = new URLSearchParams({
+		code_snippets_action: BULK_DOWNLOAD_ACTION,
+		code_snippets_bulk_download_nonce: window.CODE_SNIPPETS_MANAGE?.bulkDownloadNonce ?? '',
+		snippets: JSON.stringify(
+			snippets.map(({ id, network }) => ({ id, network }))
+		)
+	})
+
+	const response = await fetch(window.location.href, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+		},
+		body: body.toString(),
+		credentials: 'same-origin'
+	})
+
+	if (!response.ok) {
+		throw new Error(await response.text())
+	}
+
+	const blob = await response.blob()
+	const filename = response.headers.get('X-Suggested-Filename') ?? BULK_DOWNLOAD_FILENAME
+	const mimeType = '' === blob.type
+		? response.headers.get('Content-Type') ?? 'application/zip'
+		: blob.type
+
+	downloadAsFile(blob, filename, mimeType)
+}
 
 const SnippetStatusCounts = () => {
 	const { currentStatus, setCurrentStatus } = useSnippetsFilters()
@@ -183,7 +231,10 @@ const NoItemsMessage = () => {
 }
 
 const useBulkActions = (allSnippets: Snippet[]): ListTableBulkAction<Snippet['id']>[] =>
-	useMemo(
+{
+	const api = useSnippetsAPI()
+
+	return useMemo(
 		() => [
 			{
 				name: __('Activate', 'code-snippets'),
@@ -207,16 +258,29 @@ const useBulkActions = (allSnippets: Snippet[]): ListTableBulkAction<Snippet['id
 				}
 			},
 			{
-				name: __('Export code', 'code-snippets'),
-				apply: () => Promise.resolve()
+				name: __('Download', 'code-snippets'),
+				apply: (selected: Set<Snippet['id']>) => {
+					const selectedSnippets = allSnippets.filter(snippet => selected.has(snippet.id))
+
+					if (0 === selectedSnippets.length) {
+						return Promise.resolve()
+					}
+
+					if (1 === selectedSnippets.length || !window.CODE_SNIPPETS_MANAGE?.supportsZipDownloads) {
+						return downloadSnippetFilesIndividually(selectedSnippets, api.exportCode)
+					}
+
+					return downloadBulkSnippetArchive(selectedSnippets)
+				}
 			},
 			{
 				name: __('Trash', 'code-snippets'),
 				apply: () => Promise.resolve()
 			}
 		],
-		[allSnippets]
+		[allSnippets, api.exportCode]
 	)
+}
 
 export const SnippetsListTable: React.FC = () => {
 	const { currentStatus, setCurrentStatus } = useSnippetsFilters()

--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -29,24 +29,7 @@ const STATUS_LABELS: [SnippetStatus, string][] = [
 ]
 
 const BULK_DOWNLOAD_ACTION = 'bulk-download'
-const BULK_DOWNLOAD_FRAME_NAME = 'code-snippets-bulk-download-frame'
 const INDIVIDUAL_DOWNLOAD_DELAY_MS = 200
-
-const getBulkDownloadFrame = (): HTMLIFrameElement => {
-	const existingFrame = document.getElementById(BULK_DOWNLOAD_FRAME_NAME)
-
-	if (existingFrame instanceof HTMLIFrameElement) {
-		return existingFrame
-	}
-
-	const frame = document.createElement('iframe')
-	frame.id = BULK_DOWNLOAD_FRAME_NAME
-	frame.name = BULK_DOWNLOAD_FRAME_NAME
-	frame.hidden = true
-	document.body.appendChild(frame)
-
-	return frame
-}
 
 const appendHiddenField = (form: HTMLFormElement, name: string, value: string) => {
 	const input = document.createElement('input')
@@ -61,12 +44,10 @@ const submitBulkSnippetDownload = (snippets: readonly Snippet[]): Promise<void> 
 		return Promise.resolve()
 	}
 
-	const frame = getBulkDownloadFrame()
 	const form = document.createElement('form')
 
 	form.method = 'post'
 	form.action = window.location.href
-	form.target = frame.name
 	form.hidden = true
 
 	appendHiddenField(form, 'code_snippets_action', BULK_DOWNLOAD_ACTION)

--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -4,6 +4,7 @@ import { createInterpolateElement } from '@wordpress/element'
 import { useRestAPI } from '../../../hooks/useRestAPI'
 import { useSnippetsList } from '../../../hooks/useSnippetsList'
 import { handleUnknownError } from '../../../utils/errors'
+import { downloadBulkSnippetExportFile } from '../../../utils/files'
 import { REST_BASES } from '../../../utils/restAPI'
 import { getSnippetType } from '../../../utils/snippets/snippets'
 import { buildUrl } from '../../../utils/urls'
@@ -15,33 +16,6 @@ import { TableColumns } from './TableColumns'
 import type { SnippetStatus} from './WithSnippetsTableFilters'
 import type { ListTableBulkAction } from '../../common/ListTable'
 import type { Snippet } from '../../../types/Snippet'
-
-const actions: ListTableBulkAction<Snippet['id']>[] = [
-	{
-		name: __('Activate', 'code-snippets'),
-		apply: () => Promise.resolve()
-	},
-	{
-		name: __('Deactivate', 'code-snippets'),
-		apply: () => Promise.resolve()
-	},
-	{
-		name: __('Clone', 'code-snippets'),
-		apply: () => Promise.resolve()
-	},
-	{
-		name: __('Export', 'code-snippets'),
-		apply: () => Promise.resolve()
-	},
-	{
-		name: __('Export code', 'code-snippets'),
-		apply: () => Promise.resolve()
-	},
-	{
-		name: __('Trash', 'code-snippets'),
-		apply: () => Promise.resolve()
-	}
-]
 
 const STATUS_LABELS: [SnippetStatus, string][] = [
 	['all', __('All', 'code-snippets')],
@@ -176,8 +150,43 @@ export const SnippetsListTable: React.FC = () => {
 	const { currentStatus, setCurrentStatus } = useSnippetsFilters()
 	const { snippetsByStatus } = useFilteredSnippets()
 
+	const allSnippets = useMemo(() => snippetsByStatus.get('all') ?? [], [snippetsByStatus])
 	const totalItems = snippetsByStatus.get(currentStatus)?.length ?? 0
 	const itemsPerPage = window.CODE_SNIPPETS_MANAGE?.snippetsPerPage
+	const actions: ListTableBulkAction<Snippet['id']>[] = useMemo(
+		() => [
+			{
+				name: __('Activate', 'code-snippets'),
+				apply: () => Promise.resolve()
+			},
+			{
+				name: __('Deactivate', 'code-snippets'),
+				apply: () => Promise.resolve()
+			},
+			{
+				name: __('Clone', 'code-snippets'),
+				apply: () => Promise.resolve()
+			},
+			{
+				name: __('Export', 'code-snippets'),
+				apply: (selected: Set<Snippet['id']>) => {
+					downloadBulkSnippetExportFile(
+						allSnippets.filter(snippet => selected.has(snippet.id))
+					)
+					return Promise.resolve()
+				}
+			},
+			{
+				name: __('Export code', 'code-snippets'),
+				apply: () => Promise.resolve()
+			},
+			{
+				name: __('Trash', 'code-snippets'),
+				apply: () => Promise.resolve()
+			}
+		],
+		[allSnippets]
+	)
 
 	useEffect(() => {
 		if (INDEX_STATUS !== currentStatus && !snippetsByStatus.has(currentStatus)) {

--- a/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
@@ -277,7 +277,7 @@ const baseTableColumns: ListTableColumn<Snippet>[] = [
 	{
 		id: 'desc',
 		title: __('Description', 'code-snippets'),
-		render: snippet => <RawHTML>{snippet.desc}</RawHTML>
+		render: snippet => <div className="snippet-description-content"><RawHTML>{snippet.desc}</RawHTML></div>
 	},
 	{
 		id: 'tags',

--- a/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
@@ -204,7 +204,7 @@ const TagsColumn: React.FC<ColumnProps> = ({ snippet }) =>
 
 const DateColumn: React.FC<ColumnProps> = ({ snippet }) =>
 	snippet.modified
-		? <span title={snippet.modified}>
+		? <span className="modified-column-content" title={snippet.modified}>
 			<time dateTime={snippet.modified}>
 				{humanTimeDiff(snippet.modified, undefined)}
 			</time>
@@ -248,7 +248,15 @@ const PriorityColumn: React.FC<ColumnProps> = ({ snippet }) => {
 	)
 }
 
-export const TableColumns: ListTableColumn<Snippet>[] = [
+const withHiddenState = (
+	column: ListTableColumn<Snippet>,
+	hiddenColumns: readonly string[]
+): ListTableColumn<Snippet> => ({
+	...column,
+	isHidden: hiddenColumns.includes(column.id.toString())
+})
+
+const baseTableColumns: ListTableColumn<Snippet>[] = [
 	{
 		id: 'activate',
 		render: snippet => <ActivateColumn snippet={snippet} />
@@ -289,3 +297,6 @@ export const TableColumns: ListTableColumn<Snippet>[] = [
 		render: snippet => <PriorityColumn snippet={snippet} />
 	}
 ]
+
+export const getTableColumns = (hiddenColumns: readonly string[] = []): ListTableColumn<Snippet>[] =>
+	baseTableColumns.map(column => withHiddenState(column, hiddenColumns))

--- a/src/js/components/common/ListTable/ListTable.tsx
+++ b/src/js/components/common/ListTable/ListTable.tsx
@@ -94,6 +94,76 @@ const pageItems = <T, >(
 	}
 }
 
+const getVisibleSelected = <T, K extends Key>(visibleItems: T[], getKey: (item: T) => K, selected: Set<K>): Set<K> =>
+	new Set(visibleItems.map(getKey).filter(key => selected.has(key)))
+
+const buildTableNavProps = <K extends Key>({
+	totalItems,
+	actions,
+	extraTableNav,
+	selected,
+	disabled,
+	currentPage,
+	totalPages,
+	setCurrentPage,
+	useQueryVars
+}: Omit<TableNavProps<K>, 'which'>): Omit<TableNavProps<K>, 'which'> => ({
+	totalItems,
+	actions,
+	extraTableNav,
+	selected,
+	disabled,
+	currentPage,
+	totalPages,
+	setCurrentPage,
+	useQueryVars
+})
+
+interface ListTableMarkupProps<T, K extends Key> {
+	className?: string
+	fixed?: boolean
+	striped?: boolean
+	getKey: (item: T) => K
+	columns: ListTableColumn<T>[]
+	noItems?: ReactNode
+	rowClassName?: (item: T) => string
+	tableNavProps: Omit<TableNavProps<K>, 'which'>
+	tableHeadingsProps: Omit<TableHeadingsProps<T, K>, 'which'>
+	visibleItems: T[]
+}
+
+const ListTableMarkup = <T, K extends Key>({
+	fixed,
+	striped,
+	getKey,
+	columns,
+	noItems,
+	className,
+	rowClassName,
+	tableNavProps,
+	tableHeadingsProps,
+	visibleItems
+}: ListTableMarkupProps<T, K>) => (
+	<>
+		<TableNav which="top" {...tableNavProps} />
+		<table className={classnames('wp-list-table widefat', { striped, fixed }, className)}>
+			<thead>
+				<TableHeadings which="head" {...tableHeadingsProps} />
+			</thead>
+			<tbody>
+				<TableItems
+					items={visibleItems}
+					{...{ getKey, columns, noItems, setSelected: tableHeadingsProps.setSelected, rowClassName }}
+				/>
+			</tbody>
+			<tfoot>
+				<TableHeadings which="foot" {...tableHeadingsProps} />
+			</tfoot>
+		</table>
+		<TableNav which="bottom" {...tableNavProps} />
+	</>
+)
+
 export const ListTable = <T, K extends Key>({
 	items,
 	fixed,
@@ -117,28 +187,33 @@ export const ListTable = <T, K extends Key>({
 	const visibleItems: T[] = useMemo(
 		() => pageItems(sortItems(items, sortColumn, sortDirection), { currentPage, totalPages }),
 		[items, sortColumn, sortDirection, currentPage, totalPages])
-
-	const tableNavProps: Omit<TableNavProps<K>, 'which'> =
-		{ totalItems: items.length, actions, extraTableNav, selected, disabled, currentPage, totalPages, setCurrentPage, useQueryVars }
+	const tableNavProps = buildTableNavProps<K>({
+		totalItems: items.length,
+		actions,
+		extraTableNav,
+		selected: getVisibleSelected(visibleItems, getKey, selected),
+		disabled,
+		currentPage,
+		totalPages,
+		setCurrentPage,
+		useQueryVars
+	})
 
 	const tableHeadingsProps: Omit<TableHeadingsProps<T, K>, 'which'> =
 		{ items: visibleItems, setSelected, columns, getKey, sortColumn, setSortColumn, sortDirection, setSortDirection }
 
-	return (
-		<>
-			<TableNav which="top" {...tableNavProps} />
-			<table className={classnames('wp-list-table widefat', { striped, fixed }, className)}>
-				<thead>
-					<TableHeadings which="head" {...tableHeadingsProps} />
-				</thead>
-				<tbody>
-					<TableItems items={visibleItems} {...{ getKey, columns, noItems, setSelected, rowClassName }} />
-				</tbody>
-				<tfoot>
-					<TableHeadings which="foot" {...tableHeadingsProps} />
-				</tfoot>
-			</table>
-			<TableNav which="bottom" {...tableNavProps} />
-		</>
-	)
+	return <ListTableMarkup
+		{...{
+			fixed,
+			striped,
+			getKey,
+			columns,
+			noItems,
+			className,
+			rowClassName,
+			tableNavProps,
+			tableHeadingsProps,
+			visibleItems
+		}}
+	/>
 }

--- a/src/js/components/common/ListTable/ListTable.tsx
+++ b/src/js/components/common/ListTable/ListTable.tsx
@@ -97,28 +97,6 @@ const pageItems = <T, >(
 const getVisibleSelected = <T, K extends Key>(visibleItems: T[], getKey: (item: T) => K, selected: Set<K>): Set<K> =>
 	new Set(visibleItems.map(getKey).filter(key => selected.has(key)))
 
-const buildTableNavProps = <K extends Key>({
-	totalItems,
-	actions,
-	extraTableNav,
-	selected,
-	disabled,
-	currentPage,
-	totalPages,
-	setCurrentPage,
-	useQueryVars
-}: Omit<TableNavProps<K>, 'which'>): Omit<TableNavProps<K>, 'which'> => ({
-	totalItems,
-	actions,
-	extraTableNav,
-	selected,
-	disabled,
-	currentPage,
-	totalPages,
-	setCurrentPage,
-	useQueryVars
-})
-
 interface ListTableMarkupProps<T, K extends Key> {
 	className?: string
 	fixed?: boolean
@@ -187,7 +165,7 @@ export const ListTable = <T, K extends Key>({
 	const visibleItems: T[] = useMemo(
 		() => pageItems(sortItems(items, sortColumn, sortDirection), { currentPage, totalPages }),
 		[items, sortColumn, sortDirection, currentPage, totalPages])
-	const tableNavProps = buildTableNavProps<K>({
+	const tableNavProps = {
 		totalItems: items.length,
 		actions,
 		extraTableNav,
@@ -197,7 +175,7 @@ export const ListTable = <T, K extends Key>({
 		totalPages,
 		setCurrentPage,
 		useQueryVars
-	})
+	}
 
 	const tableHeadingsProps: Omit<TableHeadingsProps<T, K>, 'which'> =
 		{ items: visibleItems, setSelected, columns, getKey, sortColumn, setSortColumn, sortDirection, setSortDirection }

--- a/src/js/components/common/ListTable/TableHeadings.tsx
+++ b/src/js/components/common/ListTable/TableHeadings.tsx
@@ -23,16 +23,22 @@ const SortableHeading = <T, >({
 }: SortableHeadingProps<T>) => {
 	const isCurrent = column.id === sortColumn?.id
 
-	const newSortDirection = isCurrent
+	const nextSortDirection = isCurrent
 		? 'asc' === sortDirection ? 'desc' : 'asc'
 		: column.defaultSortDirection ?? 'asc'
+	const classDirection = isCurrent ? sortDirection : 'asc' === nextSortDirection ? 'desc' : 'asc'
+	const ariaSort = isCurrent ? 'asc' === sortDirection ? 'ascending' : 'descending' : undefined
 
 	return (
-		<th {...cellProps} className={classnames(cellProps.className, isCurrent ? 'sorted' : 'sortable')}>
+		<th
+			{...cellProps}
+			aria-sort={ariaSort}
+			className={classnames(cellProps.className, isCurrent ? 'sorted' : 'sortable', classDirection)}
+		>
 			<a href="#" onClick={event => {
 				event.preventDefault()
 				setSortColumn(column)
-				setSortDirection(newSortDirection)
+				setSortDirection(nextSortDirection)
 			}}>
 				<span>{column.title}</span>
 				<span className="sorting-indicators">
@@ -42,7 +48,7 @@ const SortableHeading = <T, >({
 				{isCurrent ? null
 					: <span className="screen-reader-text">
 						{/* translators: Hidden accessibility text. */}
-						{'asc' === newSortDirection ? __('Sort ascending.', 'code-snippets') : __('Sort descending.', 'code-snippets')}
+						{'asc' === nextSortDirection ? __('Sort ascending.', 'code-snippets') : __('Sort descending.', 'code-snippets')}
 					</span>}
 			</a>
 		</th>

--- a/src/js/components/common/ListTable/TableHeadings.tsx
+++ b/src/js/components/common/ListTable/TableHeadings.tsx
@@ -4,57 +4,6 @@ import { __ } from '@wordpress/i18n'
 import type { ListTableColumn, ListTableProps, ListTableSortDirection } from './ListTable'
 import type { Dispatch, Key, SetStateAction, ThHTMLAttributes } from 'react'
 
-interface SortableHeadingProps<T> {
-	column: ListTableColumn<T>
-	cellProps: ThHTMLAttributes<HTMLTableCellElement>
-	sortColumn: ListTableColumn<T> | undefined
-	sortDirection: ListTableSortDirection
-	setSortColumn: Dispatch<SetStateAction<ListTableColumn<T> | undefined>>
-	setSortDirection: Dispatch<SetStateAction<ListTableSortDirection>>
-}
-
-const SortableHeading = <T, >({
-	column,
-	cellProps,
-	sortColumn,
-	setSortColumn,
-	sortDirection,
-	setSortDirection
-}: SortableHeadingProps<T>) => {
-	const isCurrent = column.id === sortColumn?.id
-
-	const nextSortDirection = isCurrent
-		? 'asc' === sortDirection ? 'desc' : 'asc'
-		: column.defaultSortDirection ?? 'asc'
-	const classDirection = isCurrent ? sortDirection : 'asc' === nextSortDirection ? 'desc' : 'asc'
-	const ariaSort = isCurrent ? 'asc' === sortDirection ? 'ascending' : 'descending' : undefined
-
-	return (
-		<th
-			{...cellProps}
-			aria-sort={ariaSort}
-			className={classnames(cellProps.className, isCurrent ? 'sorted' : 'sortable', classDirection)}
-		>
-			<a href="#" onClick={event => {
-				event.preventDefault()
-				setSortColumn(column)
-				setSortDirection(nextSortDirection)
-			}}>
-				<span>{column.title}</span>
-				<span className="sorting-indicators">
-					<span className="sorting-indicator asc" aria-hidden="true"></span>
-					<span className="sorting-indicator desc" aria-hidden="true"></span>
-				</span>
-				{isCurrent ? null
-					: <span className="screen-reader-text">
-						{/* translators: Hidden accessibility text. */}
-						{'asc' === nextSortDirection ? __('Sort ascending.', 'code-snippets') : __('Sort descending.', 'code-snippets')}
-					</span>}
-			</a>
-		</th>
-	)
-}
-
 export interface TableHeadingsProps<T, K extends Key> extends Pick<ListTableProps<T, K>, 'columns' | 'getKey' | 'items'> {
 	which: 'head' | 'foot'
 	sortColumn: ListTableColumn<T> | undefined
@@ -82,7 +31,7 @@ export const TableHeadings = <T, K extends Key>({
 				type="checkbox"
 				name="checked[]"
 				onChange={event => {
-					setSelected(new Set(event.target.checked ? items.map(getKey) : null))
+					setSelected(new Set(event.target.checked ? items.map(getKey) : []))
 				}}
 			/>
 			<label htmlFor={`cb-select-all-${which}`}>
@@ -101,8 +50,42 @@ export const TableHeadings = <T, K extends Key>({
 				)
 			}
 
-			return column.sortedValue
-				? <SortableHeading key={column.id} {...{ column, sortColumn, setSortColumn, sortDirection, setSortDirection, cellProps }} />
-				: <th key={column.id} {...cellProps}>{column.title}</th>
+			if (!column.sortedValue) {
+				return <th key={column.id} {...cellProps}>{column.title}</th>
+			}
+
+			const isCurrent = column.id === sortColumn?.id
+
+			const nextSortDirection = isCurrent
+				? 'asc' === sortDirection ? 'desc' : 'asc'
+				: column.defaultSortDirection ?? 'asc'
+			const classDirection = isCurrent ? sortDirection : 'asc' === nextSortDirection ? 'desc' : 'asc'
+			const ariaSort = isCurrent ? 'asc' === sortDirection ? 'ascending' : 'descending' : undefined
+
+			return (
+				<th
+					key={column.id}
+					{...cellProps}
+					aria-sort={ariaSort}
+					className={classnames(cellProps.className, isCurrent ? 'sorted' : 'sortable', classDirection)}
+				>
+					<a href="#" onClick={event => {
+						event.preventDefault()
+						setSortColumn(column)
+						setSortDirection(nextSortDirection)
+					}}>
+						<span>{column.title}</span>
+						<span className="sorting-indicators">
+							<span className="sorting-indicator asc" aria-hidden="true"></span>
+							<span className="sorting-indicator desc" aria-hidden="true"></span>
+						</span>
+						{isCurrent ? null
+							: <span className="screen-reader-text">
+								{/* translators: Hidden accessibility text. */}
+								{'asc' === nextSortDirection ? __('Sort ascending.', 'code-snippets') : __('Sort descending.', 'code-snippets')}
+							</span>}
+					</a>
+				</th>
+			)
 		})}
 	</tr>

--- a/src/js/components/common/ListTable/TableItems.tsx
+++ b/src/js/components/common/ListTable/TableItems.tsx
@@ -34,7 +34,9 @@ interface TableCellProps<T> {
 }
 
 const TableCell = <T, >({ item, column }: TableCellProps<T>) => {
-	const className = `${column.id}-column column-${column.id}`
+	const className = [ `${column.id}-column`, `column-${column.id}`, column.isHidden ? 'hidden' : '' ]
+		.filter(Boolean)
+		.join(' ')
 
 	return column.isHeading
 		? <th className={className}>{column.render(item)}</th>

--- a/src/js/components/common/ListTable/TableItems.tsx
+++ b/src/js/components/common/ListTable/TableItems.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import classnames from 'classnames'
 import type { Dispatch, Key, SetStateAction } from 'react'
 import type { ListTableColumn, ListTableItemsProps } from './ListTable'
 
@@ -34,9 +35,7 @@ interface TableCellProps<T> {
 }
 
 const TableCell = <T, >({ item, column }: TableCellProps<T>) => {
-	const className = [ `${column.id}-column`, `column-${column.id}`, column.isHidden ? 'hidden' : '' ]
-		.filter(Boolean)
-		.join(' ')
+	const className = classnames(`${column.id}-column`, `column-${column.id}`, { hidden: column.isHidden })
 
 	return column.isHeading
 		? <th className={className}>{column.render(item)}</th>

--- a/src/js/components/common/ListTable/TableNav.tsx
+++ b/src/js/components/common/ListTable/TableNav.tsx
@@ -87,8 +87,6 @@ const BulkActions = <K extends Key>({ which, actions, applyAction, disabled }: B
 						applyAction(selectedAction)
 							.catch(handleUnknownError)
 							.finally(() => {
-								setSelectedAction(undefined)
-								setSelectedActionName('-1')
 								setIsPerformingAction(false)
 							})
 					}

--- a/src/js/components/common/ListTable/TableNav.tsx
+++ b/src/js/components/common/ListTable/TableNav.tsx
@@ -14,13 +14,13 @@ interface BulkActionSelectProps<K extends Key> extends Required<Pick<TableNavPro
 	setSelectedAction: (action: ListTableBulkAction<K> | undefined) => void
 }
 
-const BulkActionSelect = <K extends Key>({
+const BulkActionSelect = function BulkActionSelect<K extends Key>({
 	which,
 	actions,
 	selectedActionName,
 	setSelectedActionName,
 	setSelectedAction
-}: BulkActionSelectProps<K>) => {
+}: BulkActionSelectProps<K>) {
 	const actionsMap: Map<string, ListTableBulkAction<K>> = useMemo(
 		() => new Map(
 			actions
@@ -57,10 +57,11 @@ interface BulkActionsProps<K extends Key> extends Required<Pick<TableNavProps<K>
 	disabled?: boolean
 }
 
-const BulkActions = <K extends Key>({ which, actions, applyAction, disabled }: BulkActionsProps<K>) => {
+const BulkActions = function BulkActions<K extends Key>({ which, actions, applyAction, disabled }: BulkActionsProps<K>) {
 	const [selectedAction, setSelectedAction] = useState<ListTableBulkAction<K>>()
 	const [selectedActionName, setSelectedActionName] = useState('-1')
 	const [isPerformingAction, setIsPerformingAction] = useState(false)
+	const isApplyDisabled = disabled ?? (isPerformingAction || !selectedAction)
 
 	return (
 		<div className="alignleft actions bulkactions">
@@ -78,7 +79,7 @@ const BulkActions = <K extends Key>({ which, actions, applyAction, disabled }: B
 				name="bulk_action"
 				text={__('Apply', 'code-snippets')}
 				className="action"
-				disabled={disabled ?? isPerformingAction || !selectedAction}
+				disabled={isApplyDisabled}
 				onClick={event => {
 					event.preventDefault()
 
@@ -105,7 +106,7 @@ export interface TableNavProps<K extends Key> extends ListTableNavProps<K>, Omit
 	totalPages: number | undefined
 }
 
-export const TableNav = <K extends Key>({
+export const TableNav = function TableNav<K extends Key>({
 	which,
 	actions,
 	selected,
@@ -113,21 +114,24 @@ export const TableNav = <K extends Key>({
 	totalPages = 0,
 	extraTableNav,
 	...paginationProps
-}: TableNavProps<K>) =>
-	extraTableNav || 0 < totalItems && actions
-		? <div className={`tablenav ${which}`}>
+}: TableNavProps<K>) {
+	return (
+		extraTableNav || 0 < totalItems && actions
+			? <div className={`tablenav ${which}`}>
 
-			{0 < totalItems && actions && (
-				<BulkActions
-					which={which}
-					actions={actions}
-					disabled={paginationProps.disabled}
-					applyAction={action => action.apply(selected)}
-				/>)}
+				{0 < totalItems && actions && (
+					<BulkActions
+						which={which}
+						actions={actions}
+						disabled={paginationProps.disabled}
+						applyAction={action => action.apply(selected)}
+					/>)}
 
-			{extraTableNav?.(which)}
-			{0 < totalPages && <TablePagination {...{ totalPages, totalItems, which, ...paginationProps }} />}
+				{extraTableNav?.(which)}
+				{0 < totalPages && <TablePagination {...{ totalPages, totalItems, which, ...paginationProps }} />}
 
-			<br className="clear" />
-		</div>
-		: null
+				<br className="clear" />
+			</div>
+			: null
+	)
+}

--- a/src/js/components/common/ListTable/TableNav.tsx
+++ b/src/js/components/common/ListTable/TableNav.tsx
@@ -9,10 +9,18 @@ import type { ListTableBulkAction, ListTableNavProps } from './ListTable'
 import type { Key } from 'react'
 
 interface BulkActionSelectProps<K extends Key> extends Required<Pick<TableNavProps<K>, 'which' | 'actions'>> {
+	selectedActionName: string
+	setSelectedActionName: (value: string) => void
 	setSelectedAction: (action: ListTableBulkAction<K> | undefined) => void
 }
 
-const BulkActionSelect = <K extends Key>({ which, actions, setSelectedAction }: BulkActionSelectProps<K>) => {
+const BulkActionSelect = <K extends Key>({
+	which,
+	actions,
+	selectedActionName,
+	setSelectedActionName,
+	setSelectedAction
+}: BulkActionSelectProps<K>) => {
 	const actionsMap: Map<string, ListTableBulkAction<K>> = useMemo(
 		() => new Map(
 			actions
@@ -25,7 +33,9 @@ const BulkActionSelect = <K extends Key>({ which, actions, setSelectedAction }: 
 		<select
 			name={`action${'bottom' === which ? '-2' : ''}`}
 			id={`bulk-action-selector-${which}`}
+			value={selectedActionName}
 			onChange={event => {
+				setSelectedActionName(event.target.value)
 				setSelectedAction(actionsMap.get(event.target.value))
 			}}
 		>
@@ -49,6 +59,7 @@ interface BulkActionsProps<K extends Key> extends Required<Pick<TableNavProps<K>
 
 const BulkActions = <K extends Key>({ which, actions, applyAction, disabled }: BulkActionsProps<K>) => {
 	const [selectedAction, setSelectedAction] = useState<ListTableBulkAction<K>>()
+	const [selectedActionName, setSelectedActionName] = useState('-1')
 	const [isPerformingAction, setIsPerformingAction] = useState(false)
 
 	return (
@@ -58,7 +69,9 @@ const BulkActions = <K extends Key>({ which, actions, applyAction, disabled }: B
 				{__('Select bulk action', 'code-snippets')}
 			</label>
 
-			<BulkActionSelect {...{ which, actions, setSelectedAction }} />
+			<BulkActionSelect
+				{...{ which, actions, selectedActionName, setSelectedActionName, setSelectedAction }}
+			/>
 
 			<SubmitButton
 				id={`doaction${'bottom' === which ? '-2' : ''}`}
@@ -75,6 +88,7 @@ const BulkActions = <K extends Key>({ which, actions, applyAction, disabled }: B
 							.catch(handleUnknownError)
 							.finally(() => {
 								setSelectedAction(undefined)
+								setSelectedActionName('-1')
 								setIsPerformingAction(false)
 							})
 					}

--- a/src/js/components/common/ListTable/TableNav.tsx
+++ b/src/js/components/common/ListTable/TableNav.tsx
@@ -61,7 +61,7 @@ const BulkActions = function BulkActions<K extends Key>({ which, actions, applyA
 	const [selectedAction, setSelectedAction] = useState<ListTableBulkAction<K>>()
 	const [selectedActionName, setSelectedActionName] = useState('-1')
 	const [isPerformingAction, setIsPerformingAction] = useState(false)
-	const isApplyDisabled = disabled ?? (isPerformingAction || !selectedAction)
+	const isApplyDisabled = !!disabled || isPerformingAction || !selectedAction
 
 	return (
 		<div className="alignleft actions bulkactions">

--- a/src/js/components/common/ListTable/TableNav.tsx
+++ b/src/js/components/common/ListTable/TableNav.tsx
@@ -78,7 +78,7 @@ const BulkActions = <K extends Key>({ which, actions, applyAction, disabled }: B
 				name="bulk_action"
 				text={__('Apply', 'code-snippets')}
 				className="action"
-				disabled={disabled ?? isPerformingAction}
+				disabled={disabled ?? isPerformingAction || !selectedAction}
 				onClick={event => {
 					event.preventDefault()
 

--- a/src/js/components/common/ListTable/TableNav.tsx
+++ b/src/js/components/common/ListTable/TableNav.tsx
@@ -6,21 +6,21 @@ import { SubmitButton } from '../SubmitButton'
 import { TablePagination } from './TablePagination'
 import type { TablePaginationProps } from './TablePagination'
 import type { ListTableBulkAction, ListTableNavProps } from './ListTable'
-import type { Key } from 'react'
+import type { Dispatch, Key, SetStateAction } from 'react'
 
 interface BulkActionSelectProps<K extends Key> extends Required<Pick<TableNavProps<K>, 'which' | 'actions'>> {
 	selectedActionName: string
-	setSelectedActionName: (value: string) => void
-	setSelectedAction: (action: ListTableBulkAction<K> | undefined) => void
+	setSelectedActionName: Dispatch<SetStateAction<string>>
+	setSelectedAction: Dispatch<SetStateAction<ListTableBulkAction<K> | undefined>>
 }
 
-const BulkActionSelect = function BulkActionSelect<K extends Key>({
+const BulkActionSelect = <K extends Key,>({
 	which,
 	actions,
 	selectedActionName,
 	setSelectedActionName,
 	setSelectedAction
-}: BulkActionSelectProps<K>) {
+}: BulkActionSelectProps<K>) => {
 	const actionsMap: Map<string, ListTableBulkAction<K>> = useMemo(
 		() => new Map(
 			actions
@@ -61,7 +61,6 @@ const BulkActions = function BulkActions<K extends Key>({ which, actions, applyA
 	const [selectedAction, setSelectedAction] = useState<ListTableBulkAction<K>>()
 	const [selectedActionName, setSelectedActionName] = useState('-1')
 	const [isPerformingAction, setIsPerformingAction] = useState(false)
-	const isApplyDisabled = !!disabled || isPerformingAction || !selectedAction
 
 	return (
 		<div className="alignleft actions bulkactions">
@@ -79,7 +78,7 @@ const BulkActions = function BulkActions<K extends Key>({ which, actions, applyA
 				name="bulk_action"
 				text={__('Apply', 'code-snippets')}
 				className="action"
-				disabled={isApplyDisabled}
+				disabled={!!disabled || isPerformingAction || !selectedAction}
 				onClick={event => {
 					event.preventDefault()
 
@@ -106,7 +105,7 @@ export interface TableNavProps<K extends Key> extends ListTableNavProps<K>, Omit
 	totalPages: number | undefined
 }
 
-export const TableNav = function TableNav<K extends Key>({
+export const TableNav = <K extends Key,>({
 	which,
 	actions,
 	selected,
@@ -114,24 +113,21 @@ export const TableNav = function TableNav<K extends Key>({
 	totalPages = 0,
 	extraTableNav,
 	...paginationProps
-}: TableNavProps<K>) {
-	return (
-		extraTableNav || 0 < totalItems && actions
-			? <div className={`tablenav ${which}`}>
+}: TableNavProps<K>) =>
+	extraTableNav || 0 < totalItems && actions
+		? <div className={`tablenav ${which}`}>
 
-				{0 < totalItems && actions && (
-					<BulkActions
-						which={which}
-						actions={actions}
-						disabled={paginationProps.disabled}
-						applyAction={action => action.apply(selected)}
-					/>)}
+			{0 < totalItems && actions && (
+				<BulkActions
+					which={which}
+					actions={actions}
+					disabled={paginationProps.disabled}
+					applyAction={action => action.apply(selected)}
+				/>)}
 
-				{extraTableNav?.(which)}
-				{0 < totalPages && <TablePagination {...{ totalPages, totalItems, which, ...paginationProps }} />}
+			{extraTableNav?.(which)}
+			{0 < totalPages && <TablePagination {...{ totalPages, totalItems, which, ...paginationProps }} />}
 
-				<br className="clear" />
-			</div>
-			: null
-	)
-}
+			<br className="clear" />
+		</div>
+		: null

--- a/src/js/hooks/useSubmitSnippet.ts
+++ b/src/js/hooks/useSubmitSnippet.ts
@@ -76,7 +76,10 @@ const getActivationErrorNotice = (snippet: Snippet): ['error', string, string, s
 	'error',
 	__('Snippet could not be activated.', 'code-snippets'),
 	// translators: %s: single-line PHP error message.
-	sprintf(__('The snippet was saved, but remains inactive due to this error: %s', 'code-snippets'), snippet.code_error?.[0] ?? ''),
+	sprintf(
+		__('The snippet was saved, but remains inactive due to this error: <strong>%s</strong>', 'code-snippets'),
+		snippet.code_error?.[0] ?? ''
+	),
 	snippet.code_error_trace ?? undefined
 ]
 

--- a/src/js/hooks/useSubmitSnippet.ts
+++ b/src/js/hooks/useSubmitSnippet.ts
@@ -84,13 +84,21 @@ export const useSubmitSnippet = (): UseSubmitSnippet => {
 		setCurrentNotice(undefined)
 		setIsWorking(true)
 
+		const request = { ...snippet }
+
+		if (SubmitSnippetAction.SAVE_AND_ACTIVATE === action) {
+			request.active = true
+		} else if (SubmitSnippetAction.SAVE_AND_DEACTIVATE === action) {
+			request.active = false
+		}
+
 		const result = await (async (): Promise<Snippet | string | undefined> => {
 			try {
-				const { id } = snippet
+				const { id } = request
 
 				const response = await (undefined === id || 0 === id
-					? api.create(snippet)
-					: api.update({ ...snippet, id }))
+					? api.create(request)
+					: api.update({ ...request, id }))
 
 				return response.id ? createSnippetObject(response) : undefined
 			} catch (error) {
@@ -104,7 +112,7 @@ export const useSubmitSnippet = (): UseSubmitSnippet => {
 
 		if (undefined === result || 'string' === typeof result) {
 			const message = [
-				snippet.id ? messages.failedUpdate : messages.failedCreate,
+				request.id ? messages.failedUpdate : messages.failedCreate,
 				result ?? __('The server did not send a valid response.', 'code-snippets')
 			]
 
@@ -123,7 +131,7 @@ export const useSubmitSnippet = (): UseSubmitSnippet => {
 			setCurrentNotice(['updated', getSuccessNotice(snippet, result, action)])
 		}
 
-		if (snippet.id && result.id) {
+		if (request.id && result.id) {
 			window.document.title = window.document.title.replace(snippetMessages.addNew, messages.edit)
 			window.history.replaceState({}, '', buildUrl(window.CODE_SNIPPETS?.urls.edit, { id: result.id }))
 		}

--- a/src/js/hooks/useSubmitSnippet.ts
+++ b/src/js/hooks/useSubmitSnippet.ts
@@ -77,7 +77,7 @@ const getActivationErrorNotice = (snippet: Snippet): ['error', string, string, s
 	__('Snippet could not be activated.', 'code-snippets'),
 	// translators: %s: single-line PHP error message.
 	sprintf(
-		__('The snippet was saved, but remains inactive due to this error: <strong>%s</strong>', 'code-snippets'),
+		__('The snippet was saved, but remains inactive due to this error: %s', 'code-snippets'),
 		snippet.code_error?.[0] ?? ''
 	),
 	snippet.code_error_trace ?? undefined

--- a/src/js/hooks/useSubmitSnippet.ts
+++ b/src/js/hooks/useSubmitSnippet.ts
@@ -126,7 +126,7 @@ export const useSubmitSnippet = (): UseSubmitSnippet => {
 			setCurrentNotice([
 				'error',
 				// translators: %s: single-line PHP error message.
-				sprintf(__('Snippet could not be activated: %s', 'code-snippets'), result.code_error[0]),
+				sprintf(__('Snippet could not be activated: <strong>%s</strong>', 'code-snippets'), result.code_error[0]),
 				__('The snippet was saved, but remains inactive.', 'code-snippets'),
 				result.code_error_trace ?? undefined
 			])

--- a/src/js/hooks/useSubmitSnippet.ts
+++ b/src/js/hooks/useSubmitSnippet.ts
@@ -1,11 +1,12 @@
-import { __, sprintf } from '@wordpress/i18n'
+import { __ } from '@wordpress/i18n'
 import { isAxiosError } from 'axios'
-import { useCallback } from 'react'
+import { createElement , useCallback } from 'react'
 import { useSnippetForm } from '../components/EditMenu/SnippetForm/WithSnippetFormContext'
 import { createSnippetObject, isCondition } from '../utils/snippets/snippets'
 import { buildUrl } from '../utils/urls'
 import { useSnippetsAPI } from './useSnippetsAPI'
 import type { Snippet } from '../types/Snippet'
+import type { ScreenNotice } from '../types/ScreenNotice'
 
 const snippetMessages = <const> {
 	addNew: __('Create New Snippet', 'code-snippets'),
@@ -72,13 +73,15 @@ const getSuccessNotice = (
 	}
 }
 
-const getActivationErrorNotice = (snippet: Snippet): ['error', string, string, string?] => [
+const getActivationErrorNotice = (snippet: Snippet): ScreenNotice => [
 	'error',
 	__('Snippet could not be activated.', 'code-snippets'),
-	// translators: %s: single-line PHP error message.
-	sprintf(
-		__('The snippet was saved, but remains inactive due to this error: %s', 'code-snippets'),
-		snippet.code_error?.[0] ?? ''
+	createElement(
+		'span',
+		null,
+		__('The snippet was saved, but remains inactive due to this error:', 'code-snippets'),
+		' ',
+		createElement('strong', null, snippet.code_error?.[0] ?? '')
 	),
 	snippet.code_error_trace ?? undefined
 ]

--- a/src/js/hooks/useSubmitSnippet.ts
+++ b/src/js/hooks/useSubmitSnippet.ts
@@ -1,4 +1,4 @@
-import { __, sprintf } from '@wordpress/i18n'
+import { __ } from '@wordpress/i18n'
 import { isAxiosError } from 'axios'
 import { useCallback } from 'react'
 import { useSnippetForm } from '../components/EditMenu/SnippetForm/WithSnippetFormContext'
@@ -125,9 +125,10 @@ export const useSubmitSnippet = (): UseSubmitSnippet => {
 		if (result.code_error && SubmitSnippetAction.SAVE_AND_ACTIVATE === action) {
 			setCurrentNotice([
 				'error',
-				// translators: %s: single-line PHP error message.
-				sprintf(__('Snippet could not be activated: <strong>%s</strong>', 'code-snippets'), result.code_error[0]),
-				__('The snippet was saved, but remains inactive.', 'code-snippets'),
+				__('Snippet could not be activated.', 'code-snippets'),
+				result.code_error_trace
+					? __('The snippet was saved, but remains inactive.', 'code-snippets')
+					: result.code_error[0],
 				result.code_error_trace ?? undefined
 			])
 		} else {

--- a/src/js/hooks/useSubmitSnippet.ts
+++ b/src/js/hooks/useSubmitSnippet.ts
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n'
+import { __, sprintf } from '@wordpress/i18n'
 import { isAxiosError } from 'axios'
 import { useCallback } from 'react'
 import { useSnippetForm } from '../components/EditMenu/SnippetForm/WithSnippetFormContext'
@@ -72,6 +72,14 @@ const getSuccessNotice = (
 	}
 }
 
+const getActivationErrorNotice = (snippet: Snippet): ['error', string, string, string?] => [
+	'error',
+	__('Snippet could not be activated.', 'code-snippets'),
+	// translators: %s: single-line PHP error message.
+	sprintf(__('The snippet was saved, but remains inactive due to this error: %s', 'code-snippets'), snippet.code_error?.[0] ?? ''),
+	snippet.code_error_trace ?? undefined
+]
+
 export interface UseSubmitSnippet {
 	submitSnippet: (snippet: Partial<Snippet> & Pick<Snippet, 'network'>, action?: SubmitSnippetAction) => Promise<Snippet | undefined>
 }
@@ -123,14 +131,7 @@ export const useSubmitSnippet = (): UseSubmitSnippet => {
 		setSnippet(result)
 
 		if (result.code_error && SubmitSnippetAction.SAVE_AND_ACTIVATE === action) {
-			setCurrentNotice([
-				'error',
-				__('Snippet could not be activated.', 'code-snippets'),
-				result.code_error_trace
-					? __('The snippet was saved, but remains inactive.', 'code-snippets')
-					: result.code_error[0],
-				result.code_error_trace ?? undefined
-			])
+			setCurrentNotice(getActivationErrorNotice(result))
 		} else {
 			setCurrentNotice(['updated', getSuccessNotice(snippet, result, action)])
 		}

--- a/src/js/hooks/useSubmitSnippet.ts
+++ b/src/js/hooks/useSubmitSnippet.ts
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n'
+import { __, sprintf } from '@wordpress/i18n'
 import { isAxiosError } from 'axios'
 import { useCallback } from 'react'
 import { useSnippetForm } from '../components/EditMenu/SnippetForm/WithSnippetFormContext'
@@ -122,10 +122,13 @@ export const useSubmitSnippet = (): UseSubmitSnippet => {
 
 		setSnippet(result)
 
-		if (result.code_error) {
+		if (result.code_error && SubmitSnippetAction.SAVE_AND_ACTIVATE === action) {
 			setCurrentNotice([
 				'error',
-				__('Snippet could not be activated because the code contains an error. See details below.', 'code-snippets')
+				// translators: %s: single-line PHP error message.
+				sprintf(__('Snippet could not be activated: %s', 'code-snippets'), result.code_error[0]),
+				__('The snippet was saved, but remains inactive.', 'code-snippets'),
+				result.code_error_trace ?? undefined
 			])
 		} else {
 			setCurrentNotice(['updated', getSuccessNotice(snippet, result, action)])

--- a/src/js/hooks/useSubmitSnippet.tsx
+++ b/src/js/hooks/useSubmitSnippet.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n'
 import { isAxiosError } from 'axios'
-import { createElement , useCallback } from 'react'
+import React, { useCallback } from 'react'
 import { useSnippetForm } from '../components/EditMenu/SnippetForm/WithSnippetFormContext'
 import { createSnippetObject, isCondition } from '../utils/snippets/snippets'
 import { buildUrl } from '../utils/urls'
@@ -8,7 +8,7 @@ import { useSnippetsAPI } from './useSnippetsAPI'
 import type { Snippet } from '../types/Snippet'
 import type { ScreenNotice } from '../types/ScreenNotice'
 
-const snippetMessages = <const> {
+const snippetMessages = {
 	addNew: __('Create New Snippet', 'code-snippets'),
 	edit: __('Edit Snippet', 'code-snippets'),
 	created: __('Snippet <strong>created</strong>.', 'code-snippets'),
@@ -19,7 +19,7 @@ const snippetMessages = <const> {
 	updatedExecuted: __('Snippet <strong>updated</strong> and <strong>executed</strong>.', 'code-snippets'),
 	failedCreate: __('Could not create snippet.', 'code-snippets'),
 	failedUpdate: __('Could not update snippet.', 'code-snippets')
-}
+} as const
 
 const conditionCreated = __('Condition <strong>created</strong>.', 'code-snippets')
 const conditionUpdated = __('Condition <strong>updated</strong>.', 'code-snippets')
@@ -76,13 +76,11 @@ const getSuccessNotice = (
 const getActivationErrorNotice = (snippet: Snippet): ScreenNotice => [
 	'error',
 	__('Snippet could not be activated.', 'code-snippets'),
-	createElement(
-		'span',
-		null,
-		__('The snippet was saved, but remains inactive due to this error:', 'code-snippets'),
-		' ',
-		createElement('strong', null, snippet.code_error?.[0] ?? '')
-	),
+	<span key="code-snippets-activation-error">
+		{__('The snippet was saved, but remains inactive due to this error:', 'code-snippets')}
+		{' '}
+		<strong>{snippet.code_error?.[0] ?? ''}</strong>
+	</span>,
 	snippet.code_error_trace ?? undefined
 ]
 

--- a/src/js/types/ScreenNotice.ts
+++ b/src/js/types/ScreenNotice.ts
@@ -1,1 +1,3 @@
-export type ScreenNotice = ['error' | 'updated', string, string?, string?]
+import type { ReactNode } from 'react'
+
+export type ScreenNotice = ['error' | 'updated', ReactNode, ReactNode?, string?]

--- a/src/js/types/ScreenNotice.ts
+++ b/src/js/types/ScreenNotice.ts
@@ -1,1 +1,1 @@
-export type ScreenNotice = ['error' | 'updated', string]
+export type ScreenNotice = ['error' | 'updated', string, string?, string?]

--- a/src/js/types/Snippet.ts
+++ b/src/js/types/Snippet.ts
@@ -15,6 +15,7 @@ export interface Snippet {
 	readonly conditionId: number
 	readonly lastActive?: number
 	readonly code_error?: readonly [string, number] | null
+	readonly code_error_trace?: string | null
 }
 
 export const SNIPPET_TYPES = <const> ['php', 'html', 'css', 'js', 'cond']

--- a/src/js/types/Window.ts
+++ b/src/js/types/Window.ts
@@ -61,6 +61,8 @@ declare global {
 			truncateRowValues: number | string
 			snippetsPerPage: number
 			isSafeModeActive: boolean
+			bulkDownloadNonce: string
+			supportsZipDownloads: boolean
 		}
 		readonly CODE_SNIPPETS_EDIT?: {
 			snippet: Snippet

--- a/src/js/types/Window.ts
+++ b/src/js/types/Window.ts
@@ -60,6 +60,7 @@ declare global {
 			hiddenColumns: string[]
 			truncateRowValues: number | string
 			snippetsPerPage: number
+			cloudSearchPerPage: number
 			isSafeModeActive: boolean
 			bulkDownloadNonce: string
 			supportsZipDownloads: boolean

--- a/src/js/types/Window.ts
+++ b/src/js/types/Window.ts
@@ -57,6 +57,7 @@ declare global {
 		readonly CODE_SNIPPETS_MANAGE?: {
 			snippetsList: Snippet[]
 			hasNetworkCap: boolean
+			hiddenColumns: string[]
 			snippetsPerPage: number
 			isSafeModeActive: boolean
 		}

--- a/src/js/types/Window.ts
+++ b/src/js/types/Window.ts
@@ -58,6 +58,7 @@ declare global {
 			snippetsList: Snippet[]
 			hasNetworkCap: boolean
 			hiddenColumns: string[]
+			truncateRowValues: number | string
 			snippetsPerPage: number
 			isSafeModeActive: boolean
 		}

--- a/src/js/types/schema/SnippetSchema.ts
+++ b/src/js/types/schema/SnippetSchema.ts
@@ -20,4 +20,5 @@ export interface SnippetSchema extends Readonly<Required<WritableSnippetSchema>>
 	readonly modified: string
 	readonly last_active?: number
 	readonly code_error?: readonly [string, number] | null
+	readonly code_error_trace?: string | null
 }

--- a/src/js/types/schema/SnippetsExport.ts
+++ b/src/js/types/schema/SnippetsExport.ts
@@ -1,7 +1,7 @@
-import type { Snippet } from '../Snippet'
+import type { SnippetSchema } from './SnippetSchema'
 
 export interface SnippetsExport {
 	generator: string
 	date_created: string
-	snippets: Snippet[]
+	snippets: Partial<SnippetSchema>[]
 }

--- a/src/js/utils/files.ts
+++ b/src/js/utils/files.ts
@@ -5,6 +5,10 @@ import type { Snippet } from '../types/Snippet'
 const SECOND_IN_MS = 1000
 const TIMEOUT_SECONDS = 40
 const JSON_INDENT_SPACES = 2
+const EXPORT_FILENAME = 'snippets'
+const EXPORT_GENERATOR = 'Code Snippets'
+const DEFAULT_PRIORITY = 10
+const EXPORT_DATE_LENGTH = 16
 
 const MIME_INFO = <const> {
 	php: ['php', 'text/php'],
@@ -49,4 +53,95 @@ export const downloadSnippetExportFile = (
 		const filename = `${title}.code-snippets.json`
 		downloadAsFile(JSON.stringify(content, undefined, JSON_INDENT_SPACES), filename, 'application/json')
 	}
+}
+
+const isDefaultExportValue = (field: string, value: unknown): boolean => {
+	switch (field) {
+		case 'desc':
+		case 'name':
+		case 'code':
+			return '' === value
+
+		case 'tags':
+			return Array.isArray(value) && 0 === value.length
+
+		case 'scope':
+			return 'global' === value
+
+		case 'condition_id':
+			return 0 === value
+
+		case 'active':
+		case 'locked':
+		case 'trashed':
+			return false === value
+
+		case 'priority':
+			return DEFAULT_PRIORITY === value
+
+		case 'network':
+		case 'shared_network':
+		case 'code_error':
+		case 'code_error_trace':
+			return null === value || false === value
+
+		default:
+			return undefined === value || null === value
+	}
+}
+
+const buildExportSnippet = ({
+	name,
+	desc,
+	code,
+	tags,
+	scope,
+	active,
+	locked,
+	trashed,
+	network,
+	shared_network,
+	priority,
+	conditionId,
+	code_error,
+	code_error_trace
+}: Snippet): SnippetsExport['snippets'][number] => {
+	const exportSnippet: SnippetsExport['snippets'][number] = Object.fromEntries(
+		Object.entries({
+			name,
+			desc,
+			code,
+			tags,
+			scope,
+			active,
+			locked,
+			trashed,
+			network,
+			shared_network,
+			priority,
+			condition_id: conditionId,
+			code_error,
+			code_error_trace
+		}).filter(([field, value]) => !isDefaultExportValue(field, value))
+	)
+
+	return exportSnippet
+}
+
+export const downloadBulkSnippetExportFile = (snippets: readonly Snippet[]) => {
+	if (0 === snippets.length) {
+		return
+	}
+
+	const content: SnippetsExport = {
+		generator: EXPORT_GENERATOR,
+		date_created: new Date().toISOString().slice(0, EXPORT_DATE_LENGTH).replace('T', ' '),
+		snippets: snippets.map(buildExportSnippet)
+	}
+
+	downloadAsFile(
+		JSON.stringify(content, undefined, JSON_INDENT_SPACES),
+		`${EXPORT_FILENAME}.code-snippets.json`,
+		'application/json'
+	)
 }

--- a/src/js/utils/files.ts
+++ b/src/js/utils/files.ts
@@ -57,6 +57,9 @@ export const downloadSnippetExportFile = (
 
 const isDefaultExportValue = (field: string, value: unknown): boolean => {
 	switch (field) {
+		case 'id':
+			return 0 === value
+
 		case 'desc':
 		case 'name':
 		case 'code':
@@ -79,6 +82,12 @@ const isDefaultExportValue = (field: string, value: unknown): boolean => {
 		case 'priority':
 			return DEFAULT_PRIORITY === value
 
+		case 'modified':
+			return '' === value || undefined === value || null === value
+
+		case 'last_active':
+			return 0 === value || undefined === value || null === value
+
 		case 'network':
 		case 'shared_network':
 		case 'code_error':
@@ -91,6 +100,7 @@ const isDefaultExportValue = (field: string, value: unknown): boolean => {
 }
 
 const buildExportSnippet = ({
+	id,
 	name,
 	desc,
 	code,
@@ -101,13 +111,16 @@ const buildExportSnippet = ({
 	trashed,
 	network,
 	shared_network,
+	modified,
 	priority,
 	conditionId,
+	lastActive,
 	code_error,
 	code_error_trace
 }: Snippet): SnippetsExport['snippets'][number] => {
 	const exportSnippet: SnippetsExport['snippets'][number] = Object.fromEntries(
 		Object.entries({
+			id,
 			name,
 			desc,
 			code,
@@ -118,8 +131,10 @@ const buildExportSnippet = ({
 			trashed,
 			network,
 			shared_network,
+			modified,
 			priority,
 			condition_id: conditionId,
+			last_active: lastActive,
 			code_error,
 			code_error_trace
 		}).filter(([field, value]) => !isDefaultExportValue(field, value))

--- a/src/js/utils/files.ts
+++ b/src/js/utils/files.ts
@@ -55,49 +55,32 @@ export const downloadSnippetExportFile = (
 	}
 }
 
-const isDefaultExportValue = (field: string, value: unknown): boolean => {
-	switch (field) {
-		case 'id':
-			return 0 === value
+type DefaultExportValueCheck = (value: unknown) => boolean
 
-		case 'desc':
-		case 'name':
-		case 'code':
-			return '' === value
+const isNullish = (value: unknown): value is undefined | null => undefined === value || null === value
 
-		case 'tags':
-			return Array.isArray(value) && 0 === value.length
-
-		case 'scope':
-			return 'global' === value
-
-		case 'condition_id':
-			return 0 === value
-
-		case 'active':
-		case 'locked':
-		case 'trashed':
-			return false === value
-
-		case 'priority':
-			return DEFAULT_PRIORITY === value
-
-		case 'modified':
-			return '' === value || undefined === value || null === value
-
-		case 'last_active':
-			return 0 === value || undefined === value || null === value
-
-		case 'network':
-		case 'shared_network':
-		case 'code_error':
-		case 'code_error_trace':
-			return null === value || false === value
-
-		default:
-			return undefined === value || null === value
-	}
+const DEFAULT_EXPORT_VALUE_CHECKS: Record<string, DefaultExportValueCheck> = {
+	id: value => 0 === value,
+	desc: value => '' === value,
+	name: value => '' === value,
+	code: value => '' === value,
+	tags: value => Array.isArray(value) && 0 === value.length,
+	scope: value => 'global' === value,
+	condition_id: value => 0 === value,
+	active: value => false === value,
+	locked: value => false === value,
+	trashed: value => false === value,
+	priority: value => DEFAULT_PRIORITY === value,
+	modified: value => '' === value || isNullish(value),
+	last_active: value => 0 === value || isNullish(value),
+	network: value => null === value || false === value,
+	shared_network: value => null === value || false === value,
+	code_error: value => null === value || false === value,
+	code_error_trace: value => null === value || false === value
 }
+
+const isDefaultExportValue = (field: string, value: unknown): boolean =>
+	(DEFAULT_EXPORT_VALUE_CHECKS[field] ?? isNullish)(value)
 
 const buildExportSnippet = ({
 	id,

--- a/src/js/utils/snippets/objects.ts
+++ b/src/js/utils/snippets/objects.ts
@@ -18,7 +18,8 @@ const defaults: Omit<Snippet, 'tags'> = {
 	shared_network: null,
 	priority: 10,
 	conditionId: 0,
-	code_error: null
+	code_error: null,
+	code_error_trace: null
 }
 
 const isAbsInt = (value: unknown): value is number =>
@@ -59,6 +60,8 @@ export const parseSnippetObject = (fields: unknown): Snippet => {
 		...'priority' in fields && 'number' === typeof fields.priority && { priority: fields.priority },
 		...'condition_id' in fields && isAbsInt(fields.condition_id) && { conditionId: fields.condition_id },
 		...'code_error' in fields && isCodeError(fields.code_error) && { code_error: fields.code_error },
+		...'code_error_trace' in fields && ('string' === typeof fields.code_error_trace || null === fields.code_error_trace) &&
+			{ code_error_trace: fields.code_error_trace },
 		...'last_active' in fields && { lastActive: Number(fields.last_active) }
 	}
 }

--- a/src/php/Admin/Menus/Edit_Menu.php
+++ b/src/php/Admin/Menus/Edit_Menu.php
@@ -58,12 +58,7 @@ class Edit_Menu extends Admin_Menu {
 	 */
 	public function register() {
 		parent::register();
-
-		// Only preserve the edit menu if we are currently editing a snippet.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_REQUEST['page'] ) || $_REQUEST['page'] !== $this->slug ) {
-			remove_submenu_page( $this->base_slug, $this->slug );
-		}
+		remove_submenu_page( $this->base_slug, $this->slug );
 
 		// Create New Snippet menu.
 		$this->add_menu(

--- a/src/php/Admin/Menus/Edit_Menu.php
+++ b/src/php/Admin/Menus/Edit_Menu.php
@@ -134,6 +134,7 @@ class Edit_Menu extends Admin_Menu {
 
 				menuLink.dataset.codeSnippetsDisabled = 'true';
 				menuLink.setAttribute( 'aria-disabled', 'true' );
+				menuLink.style.cursor = 'pointer';
 				menuLink.removeAttribute( 'href' );
 				menuLink.addEventListener( 'click', ( event ) => {
 					event.preventDefault();

--- a/src/php/Admin/Menus/Edit_Menu.php
+++ b/src/php/Admin/Menus/Edit_Menu.php
@@ -48,6 +48,9 @@ class Edit_Menu extends Admin_Menu {
 			__( 'Edit Snippet', 'code-snippets' )
 		);
 
+		add_action( 'admin_menu', array( $this, 'maybe_hide_menu_item' ), 20 );
+		add_action( 'network_admin_menu', array( $this, 'maybe_hide_menu_item' ), 20 );
+
 		$this->remove_debug_bar_codemirror();
 	}
 
@@ -65,6 +68,25 @@ class Edit_Menu extends Admin_Menu {
 			_x( 'Add New', 'menu label', 'code-snippets' ),
 			__( 'Create New Snippet', 'code-snippets' )
 		);
+	}
+
+	/**
+	 * Hide the static Edit Snippet menu item unless a specific snippet is being edited.
+	 *
+	 * @return void
+	 */
+	public function maybe_hide_menu_item() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin menu context.
+		$current_page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin menu context.
+		$current_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
+
+		if ( $this->slug === $current_page && 0 < $current_id ) {
+			return;
+		}
+
+		remove_submenu_page( $this->base_slug, $this->slug );
 	}
 
 	/**

--- a/src/php/Admin/Menus/Edit_Menu.php
+++ b/src/php/Admin/Menus/Edit_Menu.php
@@ -4,6 +4,7 @@ namespace Code_Snippets\Admin\Menus;
 
 use Code_Snippets\Admin\Contextual_Help;
 use Code_Snippets\Model\Snippet;
+use WP_Screen;
 use function Code_Snippets\code_snippets;
 use function Code_Snippets\get_all_snippet_tags;
 use function Code_Snippets\get_snippet;
@@ -48,8 +49,7 @@ class Edit_Menu extends Admin_Menu {
 			__( 'Edit Snippet', 'code-snippets' )
 		);
 
-		add_action( 'admin_menu', array( $this, 'maybe_hide_menu_item' ), 20 );
-		add_action( 'network_admin_menu', array( $this, 'maybe_hide_menu_item' ), 20 );
+		add_action( 'current_screen', array( $this, 'maybe_hide_menu_item' ) );
 
 		$this->remove_debug_bar_codemirror();
 	}
@@ -73,16 +73,17 @@ class Edit_Menu extends Admin_Menu {
 	/**
 	 * Hide the static Edit Snippet menu item unless a specific snippet is being edited.
 	 *
+	 * @param WP_Screen $screen Current admin screen.
+	 *
 	 * @return void
 	 */
-	public function maybe_hide_menu_item() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin menu context.
-		$current_page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
-
+	public function maybe_hide_menu_item( WP_Screen $screen ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin menu context.
 		$current_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
+		$edit_hook  = get_plugin_page_hookname( $this->slug, $this->base_slug );
+		$edit_hook .= $screen->in_admin( 'network' ) ? '-network' : '';
 
-		if ( $this->slug === $current_page && 0 < $current_id ) {
+		if ( ( $screen->id === $edit_hook || $screen->base === $edit_hook ) && 0 < $current_id ) {
 			return;
 		}
 

--- a/src/php/Admin/Menus/Edit_Menu.php
+++ b/src/php/Admin/Menus/Edit_Menu.php
@@ -48,9 +48,6 @@ class Edit_Menu extends Admin_Menu {
 			__( 'Edit Snippet', 'code-snippets' )
 		);
 
-		add_action( 'admin_print_footer_scripts', array( $this, 'disable_menu_link' ) );
-		add_action( 'network_admin_print_footer_scripts', array( $this, 'disable_menu_link' ) );
-
 		$this->remove_debug_bar_codemirror();
 	}
 
@@ -115,34 +112,6 @@ class Edit_Menu extends Admin_Menu {
 	 */
 	public function render() {
 		echo '<div id="edit-snippet-container"></div>';
-	}
-
-	/**
-	 * Prevent the static Edit Snippet menu item from navigating away from the current editor state.
-	 *
-	 * @return void
-	 */
-	public function disable_menu_link() {
-		?>
-		<script>
-			document.querySelectorAll( '#adminmenu a' ).forEach( ( menuLink ) => {
-				const url = new URL( menuLink.href, window.location.origin );
-
-				if ( '<?php echo esc_js( $this->slug ); ?>' !== url.searchParams.get( 'page' ) ) {
-					return;
-				}
-
-				menuLink.dataset.codeSnippetsDisabled = 'true';
-				menuLink.setAttribute( 'aria-disabled', 'true' );
-				menuLink.style.cursor = 'pointer';
-				menuLink.removeAttribute( 'href' );
-				menuLink.addEventListener( 'click', ( event ) => {
-					event.preventDefault();
-					window.dispatchEvent( new CustomEvent( 'code_snippets_focus_editor' ) );
-				} );
-			} );
-		</script>
-		<?php
 	}
 
 	/**

--- a/src/php/Admin/Menus/Edit_Menu.php
+++ b/src/php/Admin/Menus/Edit_Menu.php
@@ -48,6 +48,9 @@ class Edit_Menu extends Admin_Menu {
 			__( 'Edit Snippet', 'code-snippets' )
 		);
 
+		add_action( 'admin_print_footer_scripts', array( $this, 'disable_menu_link' ) );
+		add_action( 'network_admin_print_footer_scripts', array( $this, 'disable_menu_link' ) );
+
 		$this->remove_debug_bar_codemirror();
 	}
 
@@ -58,7 +61,6 @@ class Edit_Menu extends Admin_Menu {
 	 */
 	public function register() {
 		parent::register();
-		remove_submenu_page( $this->base_slug, $this->slug );
 
 		// Create New Snippet menu.
 		$this->add_menu(
@@ -113,6 +115,33 @@ class Edit_Menu extends Admin_Menu {
 	 */
 	public function render() {
 		echo '<div id="edit-snippet-container"></div>';
+	}
+
+	/**
+	 * Prevent the static Edit Snippet menu item from navigating away from the current editor state.
+	 *
+	 * @return void
+	 */
+	public function disable_menu_link() {
+		?>
+		<script>
+			document.querySelectorAll( '#adminmenu a' ).forEach( ( menuLink ) => {
+				const url = new URL( menuLink.href, window.location.origin );
+
+				if ( '<?php echo esc_js( $this->slug ); ?>' !== url.searchParams.get( 'page' ) ) {
+					return;
+				}
+
+				menuLink.dataset.codeSnippetsDisabled = 'true';
+				menuLink.setAttribute( 'aria-disabled', 'true' );
+				menuLink.removeAttribute( 'href' );
+				menuLink.addEventListener( 'click', ( event ) => {
+					event.preventDefault();
+					window.dispatchEvent( new CustomEvent( 'code_snippets_focus_editor' ) );
+				} );
+			} );
+		</script>
+		<?php
 	}
 
 	/**

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -3,8 +3,11 @@
 namespace Code_Snippets\Admin\Menus;
 
 use Code_Snippets\Admin\Contextual_Help;
+use Code_Snippets\Migration\Export\Download_Code;
 use Code_Snippets\Utils\Code_Highlighter;
+use WP_Error;
 use function Code_Snippets\code_snippets;
+use function Code_Snippets\get_snippet;
 use function Code_Snippets\get_snippets;
 use function Code_Snippets\Settings\get_setting;
 use const Code_Snippets\PLUGIN_FILE;
@@ -44,6 +47,7 @@ class Manage_Menu extends Admin_Menu {
 		}
 
 		add_action( 'admin_menu', array( $this, 'register_upgrade_menu' ), 500 );
+		add_action( 'admin_init', [ $this, 'handle_bulk_download_request' ] );
 		add_action( 'admin_init', array( $this, 'save_truncation_preference' ) );
 		add_filter( 'set-screen-option', array( $this, 'save_screen_option' ), 10, 3 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_menu_css' ] );
@@ -213,12 +217,14 @@ class Manage_Menu extends Admin_Menu {
 			self::JS_HANDLE,
 			'CODE_SNIPPETS_MANAGE',
 			[
-				'hasNetworkCap'    => current_user_can( code_snippets()->get_network_cap_name() ),
+				'hasNetworkCap'      => current_user_can( code_snippets()->get_network_cap_name() ),
 				'hiddenColumns'     => $this->get_hidden_manage_columns(),
 				'truncateRowValues' => (int) $this->truncate_row_values(),
-				'snippetsPerPage'  => $this->get_snippets_per_page(),
-				'isSafeModeActive' => code_snippets()->evaluate_functions->is_safe_mode_active(),
-				'snippetsList'     => array_map(
+				'snippetsPerPage'    => $this->get_snippets_per_page(),
+				'isSafeModeActive'   => code_snippets()->evaluate_functions->is_safe_mode_active(),
+				'bulkDownloadNonce'  => wp_create_nonce( 'code_snippets_bulk_download' ),
+				'supportsZipDownloads' => class_exists( 'ZipArchive' ),
+				'snippetsList'       => array_map(
 					function ( $snippet ) {
 						return $snippet->get_fields();
 					},
@@ -388,5 +394,139 @@ class Manage_Menu extends Admin_Menu {
 	 */
 	public function save_screen_option( $status, string $option, $value ) {
 		return 'snippets_per_page' === $option ? $value : $status;
+	}
+
+	/**
+	 * Handle bulk snippet code downloads from the manage screen.
+	 *
+	 * @return void
+	 */
+	public function handle_bulk_download_request(): void {
+		if ( ! $this->is_bulk_download_request() ) {
+			return;
+		}
+
+		if ( ! current_user_can( code_snippets()->get_cap() ) ) {
+			$this->send_download_error( __( 'You are not allowed to download these snippets.', 'code-snippets' ), 403 );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified below before serving the download.
+		$nonce = isset( $_POST['code_snippets_bulk_download_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['code_snippets_bulk_download_nonce'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $nonce, 'code_snippets_bulk_download' ) ) {
+			$this->send_download_error( __( 'The download request is no longer valid. Please refresh and try again.', 'code-snippets' ), 403 );
+		}
+
+		$snippets = $this->get_requested_download_snippets();
+
+		if ( empty( $snippets ) ) {
+			$this->send_download_error( __( 'No snippets were selected for download.', 'code-snippets' ) );
+		}
+
+		$download = 1 === count( $snippets )
+			? Download_Code::build_snippet_download( $snippets[0] )
+			: Download_Code::build_archive_download( $snippets );
+
+		if ( $download instanceof WP_Error ) {
+			$status = $download->get_error_data( 'status' );
+			$this->send_download_error( $download->get_error_message(), is_numeric( $status ) ? (int) $status : 500 );
+		}
+
+		$this->send_download_response( $download );
+	}
+
+	/**
+	 * Determine whether the current request is a bulk download request.
+	 *
+	 * @return bool
+	 */
+	private function is_bulk_download_request(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only routing parameter.
+		$page = isset( $_REQUEST['page'] ) ? sanitize_key( wp_unslash( $_REQUEST['page'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Read-only action routing parameter.
+		$action = isset( $_POST['code_snippets_action'] ) ? sanitize_key( wp_unslash( $_POST['code_snippets_action'] ) ) : '';
+
+		return code_snippets()->get_menu_slug() === $page && 'bulk-download' === $action;
+	}
+
+	/**
+	 * Resolve the snippets requested for download.
+	 *
+	 * @return array<\Code_Snippets\Model\Snippet>
+	 */
+	private function get_requested_download_snippets(): array {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Verified before this method is called and parsed below.
+		$payload = isset( $_POST['snippets'] ) ? json_decode( wp_unslash( $_POST['snippets'] ), true ) : [];
+
+		if ( ! is_array( $payload ) ) {
+			return [];
+		}
+
+		$snippets = [];
+
+		foreach ( $payload as $snippet_data ) {
+			if ( ! is_array( $snippet_data ) || empty( $snippet_data['id'] ) ) {
+				continue;
+			}
+
+			$snippet = get_snippet(
+				absint( $snippet_data['id'] ),
+				! empty( $snippet_data['network'] )
+			);
+
+			if ( $snippet->id ) {
+				$snippets[] = $snippet;
+			}
+		}
+
+		return $snippets;
+	}
+
+	/**
+	 * Send a download file response and end execution.
+	 *
+	 * @param array{filename:string, content_type:string, content:string} $download Download data.
+	 *
+	 * @return void
+	 */
+	private function send_download_response( array $download ): void {
+		while ( ob_get_level() ) {
+			ob_end_clean();
+		}
+
+		nocache_headers();
+		send_nosniff_header();
+
+		header( 'Content-Description: File Transfer' );
+		header( 'Content-Type: ' . $download['content_type'] );
+		header( 'Content-Disposition: attachment; filename="' . $download['filename'] . '"' );
+		header( 'Content-Length: ' . strlen( $download['content'] ) );
+		header( 'X-Suggested-Filename: ' . $download['filename'] );
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary download payload.
+		echo $download['content'];
+		exit;
+	}
+
+	/**
+	 * Send a plain text download error response and end execution.
+	 *
+	 * @param string $message Error message.
+	 * @param int    $status  HTTP status code.
+	 *
+	 * @return void
+	 */
+	private function send_download_error( string $message, int $status = 400 ): void {
+		while ( ob_get_level() ) {
+			ob_end_clean();
+		}
+
+		status_header( $status );
+		nocache_headers();
+		send_nosniff_header();
+		header( 'Content-Type: text/plain; charset=' . get_option( 'blog_charset' ) );
+
+		echo esc_html( $message );
+		exit;
 	}
 }

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -309,7 +309,7 @@ class Manage_Menu extends Admin_Menu {
 		ob_start();
 		?>
 		<fieldset class="metabox-prefs">
-			<legend><?php esc_html_e( 'Row values', 'code-snippets' ); ?></legend>
+			<legend><?php esc_html_e( 'Table options', 'code-snippets' ); ?></legend>
 			<div class="metabox-prefs-container">
 				<label for="snippets-table-truncate-row-values">
 					<input
@@ -321,9 +321,6 @@ class Manage_Menu extends Admin_Menu {
 					/>
 					<?php esc_html_e( 'Truncate long row values', 'code-snippets' ); ?>
 				</label>
-				<p class="description">
-					<?php esc_html_e( 'Prevent long snippet titles and descriptions from stretching the table off screen.', 'code-snippets' ); ?>
-				</p>
 			</div>
 		</fieldset>
 		<?php

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -32,6 +32,11 @@ class Manage_Menu extends Admin_Menu {
 	public const CSS_HANDLE = 'code-snippets-manage';
 
 	/**
+	 * Default number of snippets shown per page in the manage table.
+	 */
+	public const DEFAULT_SNIPPETS_PER_PAGE = 100;
+
+	/**
 	 * Class constructor
 	 */
 	public function __construct() {
@@ -178,7 +183,7 @@ class Manage_Menu extends Admin_Menu {
 			'per_page',
 			array(
 				'label'   => __( 'Snippets per page', 'code-snippets' ),
-				'default' => 100,
+				'default' => $this->get_default_snippets_per_page(),
 				'option'  => 'snippets_per_page',
 			)
 		);
@@ -244,10 +249,21 @@ class Manage_Menu extends Admin_Menu {
 		$per_page = (int) get_user_option( 'snippets_per_page' );
 
 		if ( empty( $per_page ) || $per_page < 1 ) {
-			$per_page = 100;
+			$per_page = $this->get_default_snippets_per_page();
 		}
 
 		return (int) apply_filters( 'snippets_per_page', $per_page );
+	}
+
+	/**
+	 * Get the default number of snippets to show per page.
+	 *
+	 * @return int
+	 */
+	protected function get_default_snippets_per_page(): int {
+		$default = (int) apply_filters( 'code_snippets/snippets_per_page_default', self::DEFAULT_SNIPPETS_PER_PAGE );
+
+		return max( 1, $default );
 	}
 
 	/**

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -44,6 +44,7 @@ class Manage_Menu extends Admin_Menu {
 		}
 
 		add_action( 'admin_menu', array( $this, 'register_upgrade_menu' ), 500 );
+		add_action( 'admin_init', array( $this, 'save_truncation_preference' ) );
 		add_filter( 'set-screen-option', array( $this, 'save_screen_option' ), 10, 3 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_menu_css' ] );
 		add_action( 'wp_ajax_update_code_snippet', array( $this, 'ajax_callback' ) );
@@ -166,6 +167,7 @@ class Manage_Menu extends Admin_Menu {
 
 		if ( $screen ) {
 			add_filter( "manage_{$screen->id}_columns", array( $this, 'get_screen_columns' ) );
+			add_filter( 'screen_settings', array( $this, 'render_screen_settings' ), 10, 2 );
 		}
 
 		$contextual_help = new Contextual_Help( 'edit' );
@@ -212,7 +214,8 @@ class Manage_Menu extends Admin_Menu {
 			'CODE_SNIPPETS_MANAGE',
 			[
 				'hasNetworkCap'    => current_user_can( code_snippets()->get_network_cap_name() ),
-				'hiddenColumns'    => $this->get_hidden_manage_columns(),
+				'hiddenColumns'     => $this->get_hidden_manage_columns(),
+				'truncateRowValues' => (int) $this->truncate_row_values(),
 				'snippetsPerPage'  => $this->get_snippets_per_page(),
 				'isSafeModeActive' => code_snippets()->evaluate_functions->is_safe_mode_active(),
 				'snippetsList'     => array_map(
@@ -281,6 +284,84 @@ class Manage_Menu extends Admin_Menu {
 		$screen = get_current_screen();
 
 		return $screen ? get_hidden_columns( $screen ) : array();
+	}
+
+	/**
+	 * Whether to truncate long row values in the snippets table.
+	 *
+	 * @return bool
+	 */
+	protected function truncate_row_values(): bool {
+		$setting = get_user_option( 'snippets_table_truncate_row_values' );
+
+		return false === $setting ? true : (bool) $setting;
+	}
+
+	/**
+	 * Render extra Screen Options controls for the snippets table.
+	 *
+	 * @param string     $screen_settings Existing screen settings HTML.
+	 * @param \WP_Screen $screen          Current screen object.
+	 *
+	 * @return string
+	 */
+	public function render_screen_settings( string $screen_settings, \WP_Screen $screen ): string {
+		ob_start();
+		?>
+		<fieldset class="metabox-prefs">
+			<legend><?php esc_html_e( 'Row values', 'code-snippets' ); ?></legend>
+			<div class="metabox-prefs-container">
+				<label for="snippets-table-truncate-row-values">
+					<input
+						id="snippets-table-truncate-row-values"
+						name="snippets_table_truncate_row_values"
+						type="checkbox"
+						value="1"
+						<?php checked( $this->truncate_row_values() ); ?>
+					/>
+					<?php esc_html_e( 'Truncate long row values', 'code-snippets' ); ?>
+				</label>
+				<p class="description">
+					<?php esc_html_e( 'Prevent long snippet titles and descriptions from stretching the table off screen.', 'code-snippets' ); ?>
+				</p>
+			</div>
+		</fieldset>
+		<?php
+
+		return $screen_settings . ob_get_clean();
+	}
+
+	/**
+	 * Persist the snippets table truncation preference from Screen Options.
+	 *
+	 * @return void
+	 */
+	public function save_truncation_preference(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified below before persisting the option.
+		if ( empty( $_POST['wp_screen_options'] ) || ! is_array( $_POST['wp_screen_options'] ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Sanitized and matched to a known admin page.
+		$page = isset( $_REQUEST['page'] ) ? sanitize_key( wp_unslash( $_REQUEST['page'] ) ) : '';
+
+		if ( code_snippets()->get_menu_slug() !== $page || ! current_user_can( code_snippets()->get_cap() ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified here before persisting the option.
+		$nonce = isset( $_POST['screenoptionnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['screenoptionnonce'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $nonce, 'screen-options-nonce' ) ) {
+			return;
+		}
+
+		update_user_option(
+			get_current_user_id(),
+			'snippets_table_truncate_row_values',
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified above before reading the checkbox state.
+			isset( $_POST['snippets_table_truncate_row_values'] ) ? 1 : 0
+		);
 	}
 
 	/**

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -165,7 +165,7 @@ class Manage_Menu extends Admin_Menu {
 
 		$screen = get_current_screen();
 
-		if ( $screen ) {
+		if ( $screen && ! $this->is_cloud_community_view() ) {
 			add_filter( "manage_{$screen->id}_columns", array( $this, 'get_screen_columns' ) );
 			add_filter( 'screen_settings', array( $this, 'render_screen_settings' ), 10, 2 );
 		}
@@ -298,6 +298,18 @@ class Manage_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Whether the current manage subpage is the Community Cloud view.
+	 *
+	 * @return bool
+	 */
+	protected function is_cloud_community_view(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only routing parameter.
+		$subpage = isset( $_REQUEST['subpage'] ) ? sanitize_key( wp_unslash( $_REQUEST['subpage'] ) ) : '';
+
+		return 'cloud-community' === $subpage;
+	}
+
+	/**
 	 * Render extra Screen Options controls for the snippets table.
 	 *
 	 * @param string     $screen_settings Existing screen settings HTML.
@@ -306,9 +318,13 @@ class Manage_Menu extends Admin_Menu {
 	 * @return string
 	 */
 	public function render_screen_settings( string $screen_settings, \WP_Screen $screen ): string {
+		if ( $this->is_cloud_community_view() ) {
+			return $screen_settings;
+		}
+
 		ob_start();
 		?>
-		<fieldset class="metabox-prefs">
+		<fieldset class="metabox-prefs table-options-prefs">
 			<legend><?php esc_html_e( 'Table Options', 'code-snippets' ); ?></legend>
 			<div class="metabox-prefs-container">
 				<label for="snippets-table-truncate-row-values">
@@ -319,7 +335,7 @@ class Manage_Menu extends Admin_Menu {
 						value="1"
 						<?php checked( $this->truncate_row_values() ); ?>
 					/>
-					<?php esc_html_e( 'Truncate long row values', 'code-snippets' ); ?>
+					<?php esc_html_e( 'Truncate long snippet names and descriptions', 'code-snippets' ); ?>
 				</label>
 			</div>
 		</fieldset>

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -174,19 +174,17 @@ class Manage_Menu extends Admin_Menu {
 			add_filter( 'screen_settings', array( $this, 'render_screen_settings' ), 10, 2 );
 		}
 
+		add_screen_option(
+			'per_page',
+			array(
+				'label'   => __( 'Snippets per page', 'code-snippets' ),
+				'default' => 100,
+				'option'  => 'snippets_per_page',
+			)
+		);
+
 		$contextual_help = new Contextual_Help( 'edit' );
 		$contextual_help->load();
-
-		if ( ! $this->is_cloud_community_view() ) {
-			add_screen_option(
-				'per_page',
-				array(
-					'label'   => __( 'Snippets per page', 'code-snippets' ),
-					'default' => 100,
-					'option'  => 'snippets_per_page',
-				)
-			);
-		}
 	}
 
 	/**

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -223,6 +223,7 @@ class Manage_Menu extends Admin_Menu {
 				'hiddenColumns'        => $this->get_hidden_manage_columns(),
 				'truncateRowValues'    => (int) $this->truncate_row_values(),
 				'snippetsPerPage'      => $this->get_snippets_per_page(),
+				'cloudSearchPerPage'   => $this->get_cloud_search_per_page(),
 				'isSafeModeActive'     => code_snippets()->evaluate_functions->is_safe_mode_active(),
 				'bulkDownloadNonce'    => wp_create_nonce( 'code_snippets_bulk_download' ),
 				'supportsZipDownloads' => class_exists( 'ZipArchive' ),
@@ -245,10 +246,22 @@ class Manage_Menu extends Admin_Menu {
 		$per_page = (int) get_user_option( 'snippets_per_page' );
 
 		if ( empty( $per_page ) || $per_page < 1 ) {
-			$per_page = 999;
+			$per_page = 100;
 		}
 
 		return (int) apply_filters( 'snippets_per_page', $per_page );
+	}
+
+	/**
+	 * Get the number of snippets to show per page in the cloud search.
+	 *
+	 * The value defaults to the user's local snippets-per-page preference but can
+	 * be overridden independently via the `code_snippets/cloud_search/per_page` filter.
+	 *
+	 * @return int
+	 */
+	protected function get_cloud_search_per_page(): int {
+		return (int) apply_filters( 'code_snippets/cloud_search/per_page', $this->get_snippets_per_page() );
 	}
 
 	/**
@@ -429,10 +442,12 @@ class Manage_Menu extends Admin_Menu {
 		if ( $snippets instanceof WP_Error ) {
 			$status = $snippets->get_error_data( 'status' );
 			$this->send_download_error( $snippets->get_error_message(), is_numeric( $status ) ? (int) $status : 403 );
+			return;
 		}
 
 		if ( empty( $snippets ) ) {
 			$this->send_download_error( __( 'No snippets were selected for download.', 'code-snippets' ) );
+			return;
 		}
 
 		$download = 1 === count( $snippets )
@@ -442,6 +457,7 @@ class Manage_Menu extends Admin_Menu {
 		if ( $download instanceof WP_Error ) {
 			$status = $download->get_error_data( 'status' );
 			$this->send_download_error( $download->get_error_message(), is_numeric( $status ) ? (int) $status : 500 );
+			return;
 		}
 
 		$this->send_download_response( $download );

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -309,7 +309,7 @@ class Manage_Menu extends Admin_Menu {
 		ob_start();
 		?>
 		<fieldset class="metabox-prefs">
-			<legend><?php esc_html_e( 'Table options', 'code-snippets' ); ?></legend>
+			<legend><?php esc_html_e( 'Table Options', 'code-snippets' ); ?></legend>
 			<div class="metabox-prefs-container">
 				<label for="snippets-table-truncate-row-values">
 					<input

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -410,8 +410,7 @@ class Manage_Menu extends Admin_Menu {
 			$this->send_download_error( __( 'You are not allowed to download these snippets.', 'code-snippets' ), 403 );
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified below before serving the download.
-		$nonce = isset( $_POST['code_snippets_bulk_download_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['code_snippets_bulk_download_nonce'] ) ) : '';
+		$nonce = filter_input( INPUT_POST, 'code_snippets_bulk_download_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ?? '';
 
 		if ( ! wp_verify_nonce( $nonce, 'code_snippets_bulk_download' ) ) {
 			$this->send_download_error( __( 'The download request is no longer valid. Please refresh and try again.', 'code-snippets' ), 403 );
@@ -441,10 +440,8 @@ class Manage_Menu extends Admin_Menu {
 	 * @return bool
 	 */
 	private function is_bulk_download_request(): bool {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only routing parameter.
-		$page = isset( $_REQUEST['page'] ) ? sanitize_key( wp_unslash( $_REQUEST['page'] ) ) : '';
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Read-only action routing parameter.
-		$action = isset( $_POST['code_snippets_action'] ) ? sanitize_key( wp_unslash( $_POST['code_snippets_action'] ) ) : '';
+		$page = sanitize_key( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ?? '' );
+		$action = sanitize_key( filter_input( INPUT_POST, 'code_snippets_action', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ?? '' );
 
 		return code_snippets()->get_menu_slug() === $page && 'bulk-download' === $action;
 	}
@@ -455,8 +452,9 @@ class Manage_Menu extends Admin_Menu {
 	 * @return array<\Code_Snippets\Model\Snippet>
 	 */
 	private function get_requested_download_snippets(): array {
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Verified before this method is called and parsed below.
-		$payload = isset( $_POST['snippets'] ) ? json_decode( wp_unslash( $_POST['snippets'] ), true ) : [];
+		$snippets_json = filter_input( INPUT_POST, 'snippets', FILTER_DEFAULT ) ?? '';
+		$snippets_json = sanitize_textarea_field( $snippets_json );
+		$payload = '' === $snippets_json ? [] : json_decode( $snippets_json, true );
 
 		if ( ! is_array( $payload ) ) {
 			return [];

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -47,10 +47,10 @@ class Manage_Menu extends Admin_Menu {
 		}
 
 		add_action( 'admin_menu', array( $this, 'register_upgrade_menu' ), 500 );
-		add_action( 'admin_init', [ $this, 'handle_bulk_download_request' ] );
+		add_action( 'admin_init', array( $this, 'handle_bulk_download_request' ) );
 		add_action( 'admin_init', array( $this, 'save_truncation_preference' ) );
 		add_filter( 'set-screen-option', array( $this, 'save_screen_option' ), 10, 3 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_menu_css' ] );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_menu_css' ) );
 		add_action( 'wp_ajax_update_code_snippet', array( $this, 'ajax_callback' ) );
 	}
 
@@ -177,14 +177,16 @@ class Manage_Menu extends Admin_Menu {
 		$contextual_help = new Contextual_Help( 'edit' );
 		$contextual_help->load();
 
-		add_screen_option(
-			'per_page',
-			array(
-				'label'   => __( 'Snippets per page', 'code-snippets' ),
-				'default' => 999,
-				'option'  => 'snippets_per_page',
-			)
-		);
+		if ( ! $this->is_cloud_community_view() ) {
+			add_screen_option(
+				'per_page',
+				array(
+					'label'   => __( 'Snippets per page', 'code-snippets' ),
+					'default' => 100,
+					'option'  => 'snippets_per_page',
+				)
+			);
+		}
 	}
 
 	/**
@@ -217,14 +219,14 @@ class Manage_Menu extends Admin_Menu {
 			self::JS_HANDLE,
 			'CODE_SNIPPETS_MANAGE',
 			[
-				'hasNetworkCap'      => current_user_can( code_snippets()->get_network_cap_name() ),
-				'hiddenColumns'     => $this->get_hidden_manage_columns(),
-				'truncateRowValues' => (int) $this->truncate_row_values(),
-				'snippetsPerPage'    => $this->get_snippets_per_page(),
-				'isSafeModeActive'   => code_snippets()->evaluate_functions->is_safe_mode_active(),
-				'bulkDownloadNonce'  => wp_create_nonce( 'code_snippets_bulk_download' ),
+				'hasNetworkCap'        => current_user_can( code_snippets()->get_network_cap_name() ),
+				'hiddenColumns'        => $this->get_hidden_manage_columns(),
+				'truncateRowValues'    => (int) $this->truncate_row_values(),
+				'snippetsPerPage'      => $this->get_snippets_per_page(),
+				'isSafeModeActive'     => code_snippets()->evaluate_functions->is_safe_mode_active(),
+				'bulkDownloadNonce'    => wp_create_nonce( 'code_snippets_bulk_download' ),
 				'supportsZipDownloads' => class_exists( 'ZipArchive' ),
-				'snippetsList'       => array_map(
+				'snippetsList'         => array_map(
 					function ( $snippet ) {
 						return $snippet->get_fields();
 					},
@@ -412,12 +414,14 @@ class Manage_Menu extends Admin_Menu {
 
 		if ( ! current_user_can( code_snippets()->get_cap() ) ) {
 			$this->send_download_error( __( 'You are not allowed to download these snippets.', 'code-snippets' ), 403 );
+			return;
 		}
 
 		$nonce = filter_input( INPUT_POST, 'code_snippets_bulk_download_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ?? '';
 
 		if ( ! wp_verify_nonce( $nonce, 'code_snippets_bulk_download' ) ) {
 			$this->send_download_error( __( 'The download request is no longer valid. Please refresh and try again.', 'code-snippets' ), 403 );
+			return;
 		}
 
 		$snippets = $this->get_requested_download_snippets();
@@ -449,8 +453,8 @@ class Manage_Menu extends Admin_Menu {
 	 * @return bool
 	 */
 	private function is_bulk_download_request(): bool {
-		$page = sanitize_key( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ?? '' );
-		$action = sanitize_key( filter_input( INPUT_POST, 'code_snippets_action', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ?? '' );
+		$page = sanitize_key( filter_input( INPUT_GET, 'page' ) ?? '' );
+		$action = sanitize_key( filter_input( INPUT_POST, 'code_snippets_action' ) ?? '' );
 
 		return code_snippets()->get_menu_slug() === $page && 'bulk-download' === $action;
 	}
@@ -461,8 +465,7 @@ class Manage_Menu extends Admin_Menu {
 	 * @return array<\Code_Snippets\Model\Snippet>|WP_Error
 	 */
 	private function get_requested_download_snippets() {
-		$snippets_json = filter_input( INPUT_POST, 'snippets', FILTER_DEFAULT ) ?? '';
-		$snippets_json = sanitize_textarea_field( $snippets_json );
+		$snippets_json = wp_unslash( filter_input( INPUT_POST, 'snippets', FILTER_DEFAULT ) ?? '' );
 		$payload = '' === $snippets_json ? [] : json_decode( $snippets_json, true );
 
 		if ( ! is_array( $payload ) ) {
@@ -515,7 +518,7 @@ class Manage_Menu extends Admin_Menu {
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Type: ' . $download['content_type'] );
 		header( 'Content-Disposition: attachment; filename="' . $download['filename'] . '"' );
-		header( 'Content-Length: ' . strlen( $download['content'] ) );
+		header( 'Content-Length: ' . mb_strlen( $download['content'], '8bit' ) );
 		header( 'X-Suggested-Filename: ' . $download['filename'] );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary download payload.

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -162,6 +162,12 @@ class Manage_Menu extends Admin_Menu {
 	public function load() {
 		parent::load();
 
+		$screen = get_current_screen();
+
+		if ( $screen ) {
+			add_filter( "manage_{$screen->id}_columns", array( $this, 'get_screen_columns' ) );
+		}
+
 		$contextual_help = new Contextual_Help( 'edit' );
 		$contextual_help->load();
 
@@ -206,6 +212,7 @@ class Manage_Menu extends Admin_Menu {
 			'CODE_SNIPPETS_MANAGE',
 			[
 				'hasNetworkCap'    => current_user_can( code_snippets()->get_network_cap_name() ),
+				'hiddenColumns'    => $this->get_hidden_manage_columns(),
 				'snippetsPerPage'  => $this->get_snippets_per_page(),
 				'isSafeModeActive' => code_snippets()->evaluate_functions->is_safe_mode_active(),
 				'snippetsList'     => array_map(
@@ -240,6 +247,40 @@ class Manage_Menu extends Admin_Menu {
 	 */
 	public function render() {
 		echo '<div id="manage-snippets-container"></div>';
+	}
+
+	/**
+	 * Return the columns available in Screen Options for the snippets table.
+	 *
+	 * @param string[] $columns Existing columns.
+	 *
+	 * @return string[]
+	 */
+	public function get_screen_columns( array $columns = array() ): array {
+		return array_merge(
+			$columns,
+			array(
+				'_title'   => __( 'Columns', 'code-snippets' ),
+				'activate' => __( 'Active', 'code-snippets' ),
+				'name'     => __( 'Name', 'code-snippets' ),
+				'type'     => __( 'Type', 'code-snippets' ),
+				'desc'     => __( 'Description', 'code-snippets' ),
+				'tags'     => __( 'Tags', 'code-snippets' ),
+				'date'     => __( 'Modified', 'code-snippets' ),
+				'priority' => __( 'Priority', 'code-snippets' ),
+			)
+		);
+	}
+
+	/**
+	 * Get the list of columns hidden for the current user on the snippets screen.
+	 *
+	 * @return string[]
+	 */
+	protected function get_hidden_manage_columns(): array {
+		$screen = get_current_screen();
+
+		return $screen ? get_hidden_columns( $screen ) : array();
 	}
 
 	/**

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -368,6 +368,10 @@ class Manage_Menu extends Admin_Menu {
 			return;
 		}
 
+		if ( $this->is_cloud_community_view() ) {
+			return;
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified here before persisting the option.
 		$nonce = isset( $_POST['screenoptionnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['screenoptionnonce'] ) ) : '';
 

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -532,7 +532,7 @@ class Manage_Menu extends Admin_Menu {
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Type: ' . $download['content_type'] );
 		header( 'Content-Disposition: attachment; filename="' . $download['filename'] . '"' );
-		header( 'Content-Length: ' . mb_strlen( $download['content'], '8bit' ) );
+		header( 'Content-Length: ' . strlen( $download['content'] ) );
 		header( 'X-Suggested-Filename: ' . $download['filename'] );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary download payload.

--- a/src/php/Admin/Menus/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage_Menu.php
@@ -418,6 +418,11 @@ class Manage_Menu extends Admin_Menu {
 
 		$snippets = $this->get_requested_download_snippets();
 
+		if ( $snippets instanceof WP_Error ) {
+			$status = $snippets->get_error_data( 'status' );
+			$this->send_download_error( $snippets->get_error_message(), is_numeric( $status ) ? (int) $status : 403 );
+		}
+
 		if ( empty( $snippets ) ) {
 			$this->send_download_error( __( 'No snippets were selected for download.', 'code-snippets' ) );
 		}
@@ -449,9 +454,9 @@ class Manage_Menu extends Admin_Menu {
 	/**
 	 * Resolve the snippets requested for download.
 	 *
-	 * @return array<\Code_Snippets\Model\Snippet>
+	 * @return array<\Code_Snippets\Model\Snippet>|WP_Error
 	 */
-	private function get_requested_download_snippets(): array {
+	private function get_requested_download_snippets() {
 		$snippets_json = filter_input( INPUT_POST, 'snippets', FILTER_DEFAULT ) ?? '';
 		$snippets_json = sanitize_textarea_field( $snippets_json );
 		$payload = '' === $snippets_json ? [] : json_decode( $snippets_json, true );
@@ -465,6 +470,14 @@ class Manage_Menu extends Admin_Menu {
 		foreach ( $payload as $snippet_data ) {
 			if ( ! is_array( $snippet_data ) || empty( $snippet_data['id'] ) ) {
 				continue;
+			}
+
+			if ( ! empty( $snippet_data['network'] ) && ! current_user_can( code_snippets()->get_network_cap_name() ) ) {
+				return new WP_Error(
+					'code_snippets_forbidden_network_download',
+					__( 'You are not allowed to download network snippets.', 'code-snippets' ),
+					[ 'status' => 403 ]
+				);
 			}
 
 			$snippet = get_snippet(

--- a/src/php/Client/Cloud_API.php
+++ b/src/php/Client/Cloud_API.php
@@ -177,15 +177,17 @@ class Cloud_API {
 	 * @param string $search_method Search by name of codevault or keyword(s).
 	 * @param string $search        Search query.
 	 * @param int    $page          Search result page to retrieve. Defaults to '1'.
+	 * @param int    $per_page      Number of search results to retrieve per page.
 	 *
 	 * @return Cloud_Snippets Result of search query.
 	 */
-	public static function fetch_search_results( string $search_method, string $search, int $page = 1 ): Cloud_Snippets {
+	public static function fetch_search_results( string $search_method, string $search, int $page = 1, int $per_page = 10 ): Cloud_Snippets {
 		$api_url = add_query_arg(
 			[
 				's_method'   => $search_method,
 				's'          => $search,
 				'page'       => max( 0, $page - 1 ),
+				'per_page'   => max( 1, $per_page ),
 				'site_token' => self::get_local_token(),
 				'site_host'  => wp_parse_url( get_site_url(), PHP_URL_HOST ),
 			],

--- a/src/php/Client/Cloud_API.php
+++ b/src/php/Client/Cloud_API.php
@@ -20,6 +20,11 @@ use function Code_Snippets\update_snippet_fields;
 class Cloud_API {
 
 	/**
+	 * Maximum number of cloud search results allowed per page.
+	 */
+	public const MAX_RESULTS_PER_PAGE = 100;
+
+	/**
 	 * Key used to access the local-to-cloud map transient data.
 	 */
 	private const CLOUD_MAP_TRANSIENT_KEY = 'cs_local_to_cloud_map';
@@ -182,12 +187,14 @@ class Cloud_API {
 	 * @return Cloud_Snippets Result of search query.
 	 */
 	public static function fetch_search_results( string $search_method, string $search, int $page = 1, int $per_page = 10 ): Cloud_Snippets {
+		$per_page = min( self::MAX_RESULTS_PER_PAGE, max( 1, $per_page ) );
+
 		$api_url = add_query_arg(
 			[
 				's_method'   => $search_method,
 				's'          => $search,
 				'page'       => max( 0, $page - 1 ),
-				'per_page'   => max( 1, $per_page ),
+				'per_page'   => $per_page,
 				'site_token' => self::get_local_token(),
 				'site_host'  => wp_parse_url( get_site_url(), PHP_URL_HOST ),
 			],

--- a/src/php/Flat_Files/Snippet_Files.php
+++ b/src/php/Flat_Files/Snippet_Files.php
@@ -363,7 +363,7 @@ class Snippet_Files {
 	 * @return void
 	 */
 	public function sync_active_shared_network_snippets_add( $option, $value ): void {
-		if ( 'active_shared_network_snippets' !== $option ) {
+		if ( 'active_shared_network_snippets' === $option ) {
 			$this->create_active_shared_network_snippets_file( $value );
 		}
 	}
@@ -400,7 +400,7 @@ class Snippet_Files {
 	 * @return string Hashed table name.
 	 */
 	public static function get_hashed_table_name( string $table ): string {
-		return wp_hash( $table );
+		return function_exists( 'wp_hash' ) ? wp_hash( $table ) : md5( $table );
 	}
 
 	/**

--- a/src/php/Flat_Files/Snippet_Files.php
+++ b/src/php/Flat_Files/Snippet_Files.php
@@ -349,9 +349,11 @@ class Snippet_Files {
 	 * @noinspection PhpUnusedParameterInspection
 	 */
 	public function sync_active_shared_network_snippets( string $option, $old_value, $value ): void {
-		if ( 'active_shared_network_snippets' === $option ) {
-			$this->create_active_shared_network_snippets_file( $value );
+		if ( 'active_shared_network_snippets' !== $option ) {
+			return;
 		}
+
+		$this->create_active_shared_network_snippets_file( $value );
 	}
 
 	/**
@@ -363,9 +365,11 @@ class Snippet_Files {
 	 * @return void
 	 */
 	public function sync_active_shared_network_snippets_add( $option, $value ): void {
-		if ( 'active_shared_network_snippets' === $option ) {
-			$this->create_active_shared_network_snippets_file( $value );
+		if ( 'active_shared_network_snippets' !== $option ) {
+			return;
 		}
+
+		$this->create_active_shared_network_snippets_file( $value );
 	}
 
 	/**

--- a/src/php/Flat_Files/Snippet_Files.php
+++ b/src/php/Flat_Files/Snippet_Files.php
@@ -404,7 +404,8 @@ class Snippet_Files {
 	 * @return string Hashed table name.
 	 */
 	public static function get_hashed_table_name( string $table ): string {
-		return function_exists( 'wp_hash' ) ? wp_hash( $table ) : md5( $table );
+		// wp_hash() is pluggable and may not be available during early bootstrap.
+		return function_exists( 'wp_hash' ) ? \wp_hash( $table ) : md5( $table );
 	}
 
 	/**

--- a/src/php/Integration/Admin_Bar.php
+++ b/src/php/Integration/Admin_Bar.php
@@ -403,7 +403,7 @@ class Admin_Bar {
 				[
 					'id'     => self::ROOT_NODE_ID . '-snippet-' . $snippet->id,
 					'title'  => esc_html( $this->format_snippet_title( $snippet ) ),
-					'href'   => esc_url( add_query_arg( 'edit', $snippet->id, $plugin->get_menu_url( 'edit' ) ) ),
+					'href'   => esc_url( add_query_arg( 'id', $snippet->id, $plugin->get_menu_url( 'edit' ) ) ),
 					'parent' => self::ROOT_NODE_ID . '-active-snippets',
 					'meta'   => [ 'class' => 'code-snippets-snippet-item' ],
 				]
@@ -436,7 +436,7 @@ class Admin_Bar {
 				[
 					'id'     => self::ROOT_NODE_ID . '-snippet-' . $snippet->id,
 					'title'  => esc_html( $this->format_snippet_title( $snippet ) ),
-					'href'   => esc_url( add_query_arg( 'edit', $snippet->id, $plugin->get_menu_url( 'edit' ) ) ),
+					'href'   => esc_url( add_query_arg( 'id', $snippet->id, $plugin->get_menu_url( 'edit' ) ) ),
 					'parent' => self::ROOT_NODE_ID . '-inactive-snippets',
 					'meta'   => [ 'class' => 'code-snippets-snippet-item' ],
 				]

--- a/src/php/Migration/Export/Download_Code.php
+++ b/src/php/Migration/Export/Download_Code.php
@@ -7,6 +7,7 @@ use WP_Error;
 use WP_Filesystem_Direct;
 use ZipArchive;
 use function sanitize_title;
+use function wp_json_encode;
 use function wp_delete_file;
 use function wp_tempnam;
 
@@ -20,7 +21,7 @@ class Download_Code {
 	/**
 	 * Bulk download archive filename.
 	 */
-	private const ARCHIVE_FILENAME = 'snippets.code-snippets.zip';
+	private const ARCHIVE_FILENAME_TEMPLATE = 'code-snippets-%d.zip';
 
 	/**
 	 * Content types keyed by snippet type.
@@ -29,7 +30,7 @@ class Download_Code {
 	 */
 	private const CONTENT_TYPES = [
 		'php'  => 'text/php',
-		'html' => 'text/php',
+		'html' => 'text/html',
 		'css'  => 'text/css',
 		'js'   => 'text/javascript',
 		'cond' => 'application/json',
@@ -42,7 +43,7 @@ class Download_Code {
 	 */
 	private const FILE_EXTENSIONS = [
 		'php'  => 'php',
-		'html' => 'php',
+		'html' => 'html',
 		'css'  => 'css',
 		'js'   => 'js',
 		'cond' => 'json',
@@ -61,7 +62,7 @@ class Download_Code {
 		return [
 			'filename'     => self::build_filename( $snippet ),
 			'content_type' => self::CONTENT_TYPES[ $snippet->type ] ?? 'application/octet-stream',
-			'content'      => $export->generate_export(),
+			'content'      => self::build_content( $snippet, $export ),
 		];
 	}
 
@@ -73,6 +74,8 @@ class Download_Code {
 	 * @return array{filename:string, content_type:string, content:string}|WP_Error
 	 */
 	public static function build_archive_download( array $snippets ) {
+		$archive_filename = sprintf( self::ARCHIVE_FILENAME_TEMPLATE, time() );
+
 		if ( ! class_exists( ZipArchive::class ) ) {
 			return new WP_Error(
 				'zip_archive_unavailable',
@@ -81,7 +84,7 @@ class Download_Code {
 			);
 		}
 
-		$temp_file = wp_tempnam( self::ARCHIVE_FILENAME );
+		$temp_file = wp_tempnam( $archive_filename );
 
 		if ( ! is_string( $temp_file ) ) {
 			return new WP_Error(
@@ -129,10 +132,38 @@ class Download_Code {
 		}
 
 		return [
-			'filename'     => self::ARCHIVE_FILENAME,
+			'filename'     => $archive_filename,
 			'content_type' => 'application/zip',
 			'content'      => $content,
 		];
+	}
+
+	/**
+	 * Build the raw file content for a snippet download.
+	 *
+	 * @param Snippet     $snippet Snippet being exported.
+	 * @param Export_Code $export  Export helper for PHP-aware formatting.
+	 *
+	 * @return string
+	 */
+	private static function build_content( Snippet $snippet, Export_Code $export ): string {
+		switch ( $snippet->type ) {
+			case 'html':
+			case 'css':
+			case 'js':
+				return self::normalize_content( $snippet->code );
+
+			case 'cond':
+				$decoded = json_decode( $snippet->code, true );
+
+				return JSON_ERROR_NONE === json_last_error()
+					? self::normalize_content( wp_json_encode( $decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) )
+					: self::normalize_content( $snippet->code );
+
+			case 'php':
+			default:
+				return self::normalize_php_content( $export->generate_export() );
+		}
 	}
 
 	/**
@@ -152,6 +183,36 @@ class Download_Code {
 		$extension = self::FILE_EXTENSIONS[ $snippet->type ] ?? 'txt';
 
 		return "$title.code-snippets.$extension";
+	}
+
+	/**
+	 * Normalize snippet content with a trailing newline.
+	 *
+	 * @param string $content Snippet content.
+	 *
+	 * @return string
+	 */
+	private static function normalize_content( string $content ): string {
+		$content = rtrim( $content );
+
+		return '' === $content ? '' : "$content\n";
+	}
+
+	/**
+	 * Normalize PHP content to include an opening tag and trailing newline.
+	 *
+	 * @param string $content Snippet content.
+	 *
+	 * @return string
+	 */
+	private static function normalize_php_content( string $content ): string {
+		$content = ltrim( $content );
+
+		if ( 0 !== strpos( $content, '<?php' ) ) {
+			$content = "<?php\n\n" . ltrim( $content );
+		}
+
+		return self::normalize_content( $content );
 	}
 
 	/**

--- a/src/php/Migration/Export/Download_Code.php
+++ b/src/php/Migration/Export/Download_Code.php
@@ -119,6 +119,10 @@ class Download_Code {
 
 		$zip->close();
 
+		// WP_Filesystem_Direct is used intentionally here: the temp file was just created by
+		// wp_tempnam() on the local server filesystem, so the request filesystem context
+		// (FTP, SSH) is irrelevant. Using direct access avoids WP Filesystem bootstrapping
+		// overhead for a file we created and will immediately delete.
 		$filesystem = new WP_Filesystem_Direct( null );
 		$content = $filesystem->get_contents( $temp_file );
 		wp_delete_file( $temp_file );

--- a/src/php/Migration/Export/Download_Code.php
+++ b/src/php/Migration/Export/Download_Code.php
@@ -4,6 +4,7 @@ namespace Code_Snippets\Migration\Export;
 
 use Code_Snippets\Model\Snippet;
 use WP_Error;
+use WP_Filesystem_Direct;
 use ZipArchive;
 use function sanitize_title;
 use function wp_delete_file;
@@ -115,8 +116,8 @@ class Download_Code {
 
 		$zip->close();
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local temporary archive before deleting it.
-		$content = file_get_contents( $temp_file );
+		$filesystem = new WP_Filesystem_Direct( null );
+		$content = $filesystem->get_contents( $temp_file );
 		wp_delete_file( $temp_file );
 
 		if ( ! is_string( $content ) ) {

--- a/src/php/Migration/Export/Download_Code.php
+++ b/src/php/Migration/Export/Download_Code.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Code_Snippets\Migration\Export;
+
+use Code_Snippets\Model\Snippet;
+use WP_Error;
+use ZipArchive;
+use function sanitize_title;
+use function wp_delete_file;
+use function wp_tempnam;
+
+/**
+ * Builds downloadable snippet code files.
+ *
+ * @package Code_Snippets
+ */
+class Download_Code {
+
+	/**
+	 * Bulk download archive filename.
+	 */
+	private const ARCHIVE_FILENAME = 'snippets.code-snippets.zip';
+
+	/**
+	 * Content types keyed by snippet type.
+	 *
+	 * @var array<string, string>
+	 */
+	private const CONTENT_TYPES = [
+		'php'  => 'text/php',
+		'html' => 'text/php',
+		'css'  => 'text/css',
+		'js'   => 'text/javascript',
+		'cond' => 'application/json',
+	];
+
+	/**
+	 * File extensions keyed by snippet type.
+	 *
+	 * @var array<string, string>
+	 */
+	private const FILE_EXTENSIONS = [
+		'php'  => 'php',
+		'html' => 'php',
+		'css'  => 'css',
+		'js'   => 'js',
+		'cond' => 'json',
+	];
+
+	/**
+	 * Build a single downloadable code file.
+	 *
+	 * @param Snippet $snippet Snippet to export.
+	 *
+	 * @return array{filename:string, content_type:string, content:string}
+	 */
+	public static function build_snippet_download( Snippet $snippet ): array {
+		$export = new Export_Code( [ $snippet->id ], $snippet->network );
+
+		return [
+			'filename'     => self::build_filename( $snippet ),
+			'content_type' => self::CONTENT_TYPES[ $snippet->type ] ?? 'application/octet-stream',
+			'content'      => $export->generate_export(),
+		];
+	}
+
+	/**
+	 * Build a ZIP archive containing multiple snippet downloads.
+	 *
+	 * @param Snippet[] $snippets Snippets to export.
+	 *
+	 * @return array{filename:string, content_type:string, content:string}|WP_Error
+	 */
+	public static function build_archive_download( array $snippets ) {
+		if ( ! class_exists( ZipArchive::class ) ) {
+			return new WP_Error(
+				'zip_archive_unavailable',
+				__( 'Multiple snippet downloads require the ZipArchive PHP extension.', 'code-snippets' ),
+				[ 'status' => 501 ]
+			);
+		}
+
+		$temp_file = wp_tempnam( self::ARCHIVE_FILENAME );
+
+		if ( ! is_string( $temp_file ) ) {
+			return new WP_Error(
+				'zip_archive_temp_file_failed',
+				__( 'The temporary download archive could not be created.', 'code-snippets' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$zip = new ZipArchive();
+		$open_result = $zip->open( $temp_file, ZipArchive::CREATE | ZipArchive::OVERWRITE );
+
+		if ( true !== $open_result ) {
+			wp_delete_file( $temp_file );
+
+			return new WP_Error(
+				'zip_archive_open_failed',
+				__( 'The snippet download archive could not be created.', 'code-snippets' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$used_filenames = [];
+
+		foreach ( $snippets as $snippet ) {
+			$download = self::build_snippet_download( $snippet );
+			$filename = self::get_unique_filename( $download['filename'], $snippet, $used_filenames );
+
+			$zip->addFromString( $filename, $download['content'] );
+			$used_filenames[ $filename ] = true;
+		}
+
+		$zip->close();
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local temporary archive before deleting it.
+		$content = file_get_contents( $temp_file );
+		wp_delete_file( $temp_file );
+
+		if ( ! is_string( $content ) ) {
+			return new WP_Error(
+				'zip_archive_read_failed',
+				__( 'The snippet download archive could not be read.', 'code-snippets' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return [
+			'filename'     => self::ARCHIVE_FILENAME,
+			'content_type' => 'application/zip',
+			'content'      => $content,
+		];
+	}
+
+	/**
+	 * Build a deterministic filename for a snippet download.
+	 *
+	 * @param Snippet $snippet Snippet to export.
+	 *
+	 * @return string
+	 */
+	private static function build_filename( Snippet $snippet ): string {
+		$title = sanitize_title( $snippet->name );
+
+		if ( '' === $title ) {
+			$title = "snippet-$snippet->id";
+		}
+
+		$extension = self::FILE_EXTENSIONS[ $snippet->type ] ?? 'txt';
+
+		return "$title.code-snippets.$extension";
+	}
+
+	/**
+	 * Avoid duplicate filenames within the same archive.
+	 *
+	 * @param string             $filename       Proposed filename.
+	 * @param Snippet            $snippet        Snippet being exported.
+	 * @param array<string,bool> $used_filenames Archive filenames already in use.
+	 *
+	 * @return string
+	 */
+	private static function get_unique_filename( string $filename, Snippet $snippet, array $used_filenames ): string {
+		if ( ! isset( $used_filenames[ $filename ] ) ) {
+			return $filename;
+		}
+
+		$extension = self::FILE_EXTENSIONS[ $snippet->type ] ?? 'txt';
+		$title = sanitize_title( $snippet->name );
+
+		if ( '' === $title ) {
+			$title = 'snippet';
+		}
+
+		$counter = 2;
+		$unique_filename = sprintf( '%s-%d.code-snippets.%s', $title, $snippet->id, $extension );
+
+		while ( isset( $used_filenames[ $unique_filename ] ) ) {
+			$unique_filename = sprintf( '%s-%d-%d.code-snippets.%s', $title, $snippet->id, $counter, $extension );
+			++$counter;
+		}
+
+		return $unique_filename;
+	}
+}

--- a/src/php/Model/Model.php
+++ b/src/php/Model/Model.php
@@ -105,7 +105,7 @@ abstract class Model {
 	 * @return string The resolved field name.
 	 */
 	protected static function resolve_field_name( string $field ): string {
-		return self::$field_aliases[ $field ] ?? $field;
+		return static::$field_aliases[ $field ] ?? $field;
 	}
 
 	/**
@@ -199,7 +199,7 @@ abstract class Model {
 	 * @return array<string> List of field names.
 	 */
 	public function get_allowed_fields(): array {
-		return array_keys( $this->fields ) + array_keys( static::$field_aliases );
+		return array_merge( array_keys( $this->fields ), array_keys( static::$field_aliases ) );
 	}
 
 	/**

--- a/src/php/Model/Snippet.php
+++ b/src/php/Model/Snippet.php
@@ -29,6 +29,7 @@ use function Code_Snippets\Utils\get_self_option;
  * @property bool                   $shared_network     Whether the snippet is a shared network snippet.
  * @property string                 $modified           The date and time when the snippet data was most recently saved to the database.
  * @property array{string,int}|null $code_error         Code error encountered when last testing snippet code.
+ * @property string|null            $code_error_trace   Stack trace captured when last testing snippet code.
  * @property int                    $revision           Revision or version number of snippet.
  * @property string                 $cloud_id           Cloud ID and ownership status of snippet.
  *
@@ -76,6 +77,7 @@ class Snippet extends Model {
 		'shared_network' => null,
 		'modified'       => null,
 		'code_error'     => null,
+		'code_error_trace' => null,
 		'revision'       => 1,
 		'cloud_id'       => '',
 	];

--- a/src/php/REST_API/Cloud/Cloud_Snippets_REST_Controller.php
+++ b/src/php/REST_API/Cloud/Cloud_Snippets_REST_Controller.php
@@ -115,7 +115,7 @@ final class Cloud_Snippets_REST_Controller extends REST_Collection_Controller {
 		$query_params = $request->get_query_params();
 		$page = max( 1, (int) $request->get_param( 'page' ) );
 		$per_page = isset( $query_params['per_page'] )
-			? max( 1, (int) $request->get_param( 'per_page' ) )
+			? min( Cloud_API::MAX_RESULTS_PER_PAGE, max( 1, (int) $request->get_param( 'per_page' ) ) )
 			: $this->get_snippets_per_page();
 
 		$cloud_snippets = Cloud_API::fetch_search_results( $method, $query, $page, $per_page );
@@ -142,7 +142,7 @@ final class Cloud_Snippets_REST_Controller extends REST_Collection_Controller {
 	private function get_snippets_per_page(): int {
 		$per_page = (int) get_user_option( 'snippets_per_page' );
 
-		return $per_page > 0 ? $per_page : 10;
+		return $per_page > 0 ? min( Cloud_API::MAX_RESULTS_PER_PAGE, $per_page ) : 10;
 	}
 
 	/**

--- a/src/php/REST_API/Cloud/Cloud_Snippets_REST_Controller.php
+++ b/src/php/REST_API/Cloud/Cloud_Snippets_REST_Controller.php
@@ -46,6 +46,9 @@ final class Cloud_Snippets_REST_Controller extends REST_Collection_Controller {
 	 * Register REST routes.
 	 */
 	public function register_routes() {
+		$collection_args = $this->get_collection_params();
+		$collection_args['per_page']['default'] = $this->get_snippets_per_page();
+
 		register_rest_route(
 			$this->namespace,
 			$this->rest_base,
@@ -54,23 +57,26 @@ final class Cloud_Snippets_REST_Controller extends REST_Collection_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'get_items' ],
 					'permission_callback' => [ $this, 'get_items_permissions_check' ],
-					'args'                => [
-						'query'             => [
-							'description' => esc_html__( 'Search query.', 'code-snippets' ),
-							'type'        => 'string',
-							'required'    => true,
-						],
-						'searchByCodevault' => [
-							'description' => esc_html__( 'Treat the search query as the name of a CodeVault instead of a search term.', 'code-snippets' ),
-							'type'        => 'boolean',
-							'default'     => false,
-						],
-						'page'              => [
-							'description' => esc_html__( 'Page number.', 'code-snippets' ),
-							'type'        => 'integer',
-							'default'     => 1,
-						],
-					],
+					'args'                => array_merge(
+						$collection_args,
+						[
+							'query'             => [
+								'description' => esc_html__( 'Search query.', 'code-snippets' ),
+								'type'        => 'string',
+								'required'    => true,
+							],
+							'searchByCodevault' => [
+								'description' => esc_html__( 'Treat the search query as the name of a CodeVault instead of a search term.', 'code-snippets' ),
+								'type'        => 'boolean',
+								'default'     => false,
+							],
+							'page'              => [
+								'description' => esc_html__( 'Page number.', 'code-snippets' ),
+								'type'        => 'integer',
+								'default'     => 1,
+							],
+						]
+					),
 				],
 				'schema' => [ $this, 'get_item_schema' ],
 			]
@@ -106,9 +112,13 @@ final class Cloud_Snippets_REST_Controller extends REST_Collection_Controller {
 	public function get_items( $request ): WP_REST_Response {
 		$method = $request->get_param( 'searchByCodevault' ) ? 'codevault' : 'term';
 		$query = $request->get_param( 'query' );
-		$page = $request->get_param( 'page' );
+		$query_params = $request->get_query_params();
+		$page = max( 1, (int) $request->get_param( 'page' ) );
+		$per_page = isset( $query_params['per_page'] )
+			? max( 1, (int) $request->get_param( 'per_page' ) )
+			: $this->get_snippets_per_page();
 
-		$cloud_snippets = Cloud_API::fetch_search_results( $method, $query, $page );
+		$cloud_snippets = Cloud_API::fetch_search_results( $method, $query, $page, $per_page );
 
 		$results = [];
 
@@ -122,6 +132,17 @@ final class Cloud_Snippets_REST_Controller extends REST_Collection_Controller {
 		$response->header( 'X-WP-TotalPages', $cloud_snippets->total_pages );
 
 		return $response;
+	}
+
+	/**
+	 * Get the user's snippets per-page preference for Screen Options pagination.
+	 *
+	 * @return int
+	 */
+	private function get_snippets_per_page(): int {
+		$per_page = (int) get_user_option( 'snippets_per_page' );
+
+		return $per_page > 0 ? $per_page : 10;
 	}
 
 	/**

--- a/src/php/REST_API/Snippets/Snippets_REST_Controller.php
+++ b/src/php/REST_API/Snippets/Snippets_REST_Controller.php
@@ -664,7 +664,15 @@ final class Snippets_REST_Controller extends REST_Collection_Controller {
 				],
 				'code_error'     => [
 					'description' => esc_html__( 'Error message if the snippet code could not be parsed.', 'code-snippets' ),
-					'type'        => 'string',
+					'type'        => [ 'array', 'null' ],
+					'items'       => [
+						'type' => [ 'string', 'integer' ],
+					],
+					'readonly'    => true,
+				],
+				'code_error_trace' => [
+					'description' => esc_html__( 'Stack trace for the most recent snippet code error.', 'code-snippets' ),
+					'type'        => [ 'string', 'null' ],
 					'readonly'    => true,
 				],
 			],

--- a/src/php/Utils/Validator.php
+++ b/src/php/Utils/Validator.php
@@ -101,8 +101,8 @@ class Validator {
 	 * @return bool true if the identifier is not unique.
 	 */
 	private function check_duplicate_identifier( string $type, string $identifier ): bool {
-		$identifier = strtolower( $identifier );
-		$namespaced_identifier = 'code_snippets\\' . ltrim( $identifier, '\\' );
+		$identifier = strtolower( ltrim( $identifier, '\\' ) );
+		$namespaced_identifier = 'code_snippets\\' . $identifier;
 
 		if ( ! isset( $this->defined_identifiers[ $type ] ) ) {
 			switch ( $type ) {
@@ -127,11 +127,15 @@ class Validator {
 			}
 		}
 
-		$duplicate = in_array( $identifier, $this->defined_identifiers[ $type ], true ) ||
-			in_array( $namespaced_identifier, $this->defined_identifiers[ $type ], true );
+		$duplicate_identifier = in_array( $identifier, $this->defined_identifiers[ $type ], true );
+		$duplicate_namespaced = in_array( $namespaced_identifier, $this->defined_identifiers[ $type ], true );
+		$exceptions = $this->exceptions[ $type ] ?? [];
+		$exception_identifier = in_array( $identifier, $exceptions, true );
+		$exception_namespaced = in_array( $namespaced_identifier, $exceptions, true );
+
 		array_unshift( $this->defined_identifiers[ $type ], $identifier );
 
-		return $duplicate && ! ( isset( $this->exceptions[ $type ] ) && in_array( $identifier, $this->exceptions[ $type ], true ) );
+		return ( $duplicate_identifier && ! $exception_identifier ) || ( $duplicate_namespaced && ! $exception_namespaced );
 	}
 
 	/**
@@ -160,8 +164,12 @@ class Validator {
 				}
 
 				// Add the identifier to the list of exceptions.
-				$this->exceptions[ $type ] = $this->exceptions[ $type ] ?? [];
-				$this->exceptions[ $type ][] = trim( $token[1], '\'"' );
+				$identifier = strtolower( ltrim( trim( $token[1], '\'"' ), '\\' ) );
+
+				if ( '' !== $identifier ) {
+					$this->exceptions[ $type ] = $this->exceptions[ $type ] ?? [];
+					$this->exceptions[ $type ][] = $identifier;
+				}
 				continue;
 			}
 

--- a/src/php/Utils/Validator.php
+++ b/src/php/Utils/Validator.php
@@ -101,20 +101,25 @@ class Validator {
 	 * @return bool true if the identifier is not unique.
 	 */
 	private function check_duplicate_identifier( string $type, string $identifier ): bool {
+		$identifier = strtolower( $identifier );
+		$namespaced_identifier = 'code_snippets\\' . ltrim( $identifier, '\\' );
 
 		if ( ! isset( $this->defined_identifiers[ $type ] ) ) {
 			switch ( $type ) {
 				case T_FUNCTION:
 					$defined_functions = get_defined_functions();
-					$this->defined_identifiers[ T_FUNCTION ] = array_merge( $defined_functions['internal'], $defined_functions['user'] );
+					$this->defined_identifiers[ T_FUNCTION ] = array_map(
+						'strtolower',
+						array_merge( $defined_functions['internal'], $defined_functions['user'] )
+					);
 					break;
 
 				case T_CLASS:
-					$this->defined_identifiers[ T_CLASS ] = get_declared_classes();
+					$this->defined_identifiers[ T_CLASS ] = array_map( 'strtolower', get_declared_classes() );
 					break;
 
 				case T_INTERFACE:
-					$this->defined_identifiers[ T_INTERFACE ] = get_declared_interfaces();
+					$this->defined_identifiers[ T_INTERFACE ] = array_map( 'strtolower', get_declared_interfaces() );
 					break;
 
 				default:
@@ -122,7 +127,8 @@ class Validator {
 			}
 		}
 
-		$duplicate = in_array( $identifier, $this->defined_identifiers[ $type ], true );
+		$duplicate = in_array( $identifier, $this->defined_identifiers[ $type ], true ) ||
+			in_array( $namespaced_identifier, $this->defined_identifiers[ $type ], true );
 		array_unshift( $this->defined_identifiers[ $type ], $identifier );
 
 		return $duplicate && ! ( isset( $this->exceptions[ $type ] ) && in_array( $identifier, $this->exceptions[ $type ], true ) );

--- a/src/php/snippet-ops.php
+++ b/src/php/snippet-ops.php
@@ -9,7 +9,6 @@ namespace Code_Snippets;
 
 use Code_Snippets\Core\DB;
 use Exception;
-use ParseError;
 use Code_Snippets\Model\Snippet;
 use Code_Snippets\Utils\Validator;
 use Throwable;
@@ -761,8 +760,6 @@ function execute_snippet( string $code, int $id = 0, bool $force = false ) {
 
 	try {
 		$result = eval( $code );
-	} catch ( ParseError $parse_error ) {
-		$result = $parse_error;
 	} catch ( Throwable $throwable ) {
 		$result = $throwable;
 	}
@@ -894,8 +891,6 @@ function execute_snippet_from_flat_file( string $code, string $file, int $id = 0
 	try {
 		require_once $file;
 		$result = null;
-	} catch ( ParseError $parse_error ) {
-		$result = $parse_error;
 	} catch ( Throwable $throwable ) {
 		$result = $throwable;
 	}

--- a/src/php/snippet-ops.php
+++ b/src/php/snippet-ops.php
@@ -8,6 +8,7 @@
 namespace Code_Snippets;
 
 use Code_Snippets\Core\DB;
+use Exception;
 use ParseError;
 use Code_Snippets\Model\Snippet;
 use Code_Snippets\Utils\Validator;
@@ -584,6 +585,7 @@ function restore_snippet( int $id, ?bool $network = null ): bool {
  */
 function test_snippet_code( Snippet $snippet ) {
 	$snippet->code_error = null;
+	$snippet->code_error_trace = null;
 
 	if ( 'php' !== $snippet->type ) {
 		return;
@@ -594,16 +596,18 @@ function test_snippet_code( Snippet $snippet ) {
 
 	if ( $result ) {
 		$snippet->code_error = [ $result['message'], $result['line'] ];
+		$snippet->code_error_trace = ( new Exception() )->getTraceAsString();
 	}
 
 	if ( ! $snippet->code_error && 'single-use' !== $snippet->scope ) {
 		$result = execute_snippet( $snippet->code, $snippet->id, true );
 
-		if ( $result instanceof ParseError ) {
+		if ( $result instanceof Throwable ) {
 			$snippet->code_error = [
 				ucfirst( rtrim( $result->getMessage(), '.' ) ) . '.',
 				$result->getLine(),
 			];
+			$snippet->code_error_trace = $result->getTraceAsString();
 		}
 	}
 }
@@ -688,6 +692,8 @@ function save_snippet( $snippet ): ?Snippet {
 
 		$snippet->id = $wpdb->insert_id;
 		$updated = get_snippet( $snippet->id );
+		$updated->code_error = $snippet->code_error;
+		$updated->code_error_trace = $snippet->code_error_trace;
 		do_action( 'code_snippets/create_snippet', $updated, $table );
 
 		if ( $updated->id > 0 ) {
@@ -701,6 +707,8 @@ function save_snippet( $snippet ): ?Snippet {
 		$wpdb->update( $table, $data, [ 'id' => $snippet->id ], null, [ '%d' ] );
 
 		$updated = get_snippet( $snippet->id, $snippet->network );
+		$updated->code_error = $snippet->code_error;
+		$updated->code_error_trace = $snippet->code_error_trace;
 
 		do_action( 'code_snippets/update_snippet', $updated, $table, $existing, $snippet );
 
@@ -732,7 +740,7 @@ function save_snippet( $snippet ): ?Snippet {
  * @param int    $id    Snippet ID.
  * @param bool   $force Force snippet execution, even if save mode is active.
  *
- * @return ParseError|mixed Code error if encountered during execution, or result of snippet execution otherwise.
+ * @return Throwable|mixed Code error if encountered during execution, or result of snippet execution otherwise.
  *
  * @since        2.0.0
  * @noinspection PhpUndefinedConstantInspection
@@ -755,6 +763,8 @@ function execute_snippet( string $code, int $id = 0, bool $force = false ) {
 		$result = eval( $code );
 	} catch ( ParseError $parse_error ) {
 		$result = $parse_error;
+	} catch ( Throwable $throwable ) {
+		$result = $throwable;
 	}
 
 	ob_end_clean();

--- a/tests/e2e/code-snippets-edit.spec.ts
+++ b/tests/e2e/code-snippets-edit.spec.ts
@@ -73,7 +73,7 @@ test.describe('Code Snippets Admin', () => {
 
 		await helper.saveSnippet('save_and_activate')
 
-		const errorNotice = page.locator('.snippet-editor-sidebar .notice.error').first()
+		const errorNotice = page.locator('.wrap > .notice.error').first()
 		await expect(errorNotice).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
 		await expect(errorNotice).toContainText('Snippet could not be activated:')
 		await expect(errorNotice).toContainText('Call to undefined function missing_runtime_function_call()')

--- a/tests/e2e/code-snippets-edit.spec.ts
+++ b/tests/e2e/code-snippets-edit.spec.ts
@@ -94,9 +94,9 @@ test.describe('Code Snippets Admin', () => {
 
 		const errorNotice = page.locator('.wrap > .notice.error').first()
 		await expect(errorNotice).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
-		await expect(errorNotice).toContainText('Snippet could not be activated:')
+		await expect(errorNotice).toContainText('Snippet could not be activated.')
 		await expect(errorNotice).toContainText('Call to undefined function missing_runtime_function_call()')
-		await expect(errorNotice).toContainText('The snippet was saved, but remains inactive.')
+		await expect(errorNotice).toContainText('The snippet was saved, but remains inactive due to this error:')
 
 		const traceDetails = errorNotice.locator('details').first()
 		await expect(traceDetails).toBeVisible({ timeout: TIMEOUTS.DEFAULT })

--- a/tests/e2e/code-snippets-edit.spec.ts
+++ b/tests/e2e/code-snippets-edit.spec.ts
@@ -63,6 +63,25 @@ test.describe('Code Snippets Admin', () => {
 		await helper.cleanupSnippet(snippetName)
 	})
 
+	test('Edit menu shortcut keeps operable button semantics', async ({ page }) => {
+		const snippetName = SnippetsTestHelper.makeUniqueSnippetName()
+		await helper.createSnippet({
+			name: snippetName,
+			code: "add_filter('show_admin_bar', '__return_false');"
+		})
+
+		await helper.openSnippet(snippetName)
+
+		const editMenuLink = page.locator('#adminmenu a.code-snippets-edit-menu-link').first()
+
+		await expect(editMenuLink).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
+		await expect(editMenuLink).toHaveAttribute('role', 'button')
+		await expect(editMenuLink).toHaveAttribute('tabindex', '0')
+		await expect(editMenuLink).not.toHaveAttribute('aria-disabled', /true/)
+
+		await helper.cleanupSnippet(snippetName)
+	})
+
 	test('Shows an error notice when activation fails after saving', async ({ page }) => {
 		const snippetName = SnippetsTestHelper.makeUniqueSnippetName()
 		await helper.clickAddNewSnippet()

--- a/tests/e2e/code-snippets-edit.spec.ts
+++ b/tests/e2e/code-snippets-edit.spec.ts
@@ -63,6 +63,38 @@ test.describe('Code Snippets Admin', () => {
 		await helper.cleanupSnippet(snippetName)
 	})
 
+	test('Shows an error notice when activation fails after saving', async ({ page }) => {
+		const snippetName = SnippetsTestHelper.makeUniqueSnippetName()
+		await helper.clickAddNewSnippet()
+		await helper.fillSnippetForm({
+			name: snippetName,
+			code: 'missing_runtime_function_call();'
+		})
+
+		await helper.saveSnippet('save_and_activate')
+
+		const errorNotice = page.locator('.snippet-editor-sidebar .notice.error').first()
+		await expect(errorNotice).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
+		await expect(errorNotice).toContainText('Snippet could not be activated:')
+		await expect(errorNotice).toContainText('Call to undefined function missing_runtime_function_call()')
+		await expect(errorNotice).toContainText('The snippet was saved, but remains inactive.')
+
+		const traceDetails = errorNotice.locator('details').first()
+		await expect(traceDetails).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
+		await expect(traceDetails.locator('summary')).toContainText('View stack trace')
+
+		await helper.navigateToSnippetsAdmin()
+
+		const snippetRow = page
+			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${snippetName}"))`)
+			.first()
+
+		await expect(snippetRow).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
+		await expect(snippetRow.locator(SELECTORS.SNIPPET_TOGGLE).first()).not.toBeChecked({ timeout: TIMEOUTS.DEFAULT })
+
+		await helper.cleanupSnippet(snippetName)
+	})
+
 	test('Can delete a snippet', async () => {
 		const snippetName = SnippetsTestHelper.makeUniqueSnippetName()
 		await helper.createSnippet({

--- a/tests/e2e/code-snippets-edit.spec.ts
+++ b/tests/e2e/code-snippets-edit.spec.ts
@@ -1,6 +1,6 @@
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { SnippetsTestHelper } from './helpers/SnippetsTestHelper'
-import { MESSAGES, SELECTORS } from './helpers/constants'
+import { MESSAGES, SELECTORS, TIMEOUTS } from './helpers/constants'
 
 test.describe('Code Snippets Admin', () => {
 	let helper: SnippetsTestHelper
@@ -38,6 +38,29 @@ test.describe('Code Snippets Admin', () => {
 		// Deactivate it (Status toggle + save in the new UI).
 		await helper.saveSnippet('save_and_deactivate')
 		await helper.expectSuccessMessage(MESSAGES.SNIPPET_UPDATED_AND_DEACTIVATED)
+	})
+
+	test('Can activate a new snippet on the first save attempt', async ({ page }) => {
+		const snippetName = SnippetsTestHelper.makeUniqueSnippetName()
+		await helper.clickAddNewSnippet()
+		await helper.fillSnippetForm({
+			name: snippetName,
+			code: "add_filter('show_admin_bar', '__return_false');"
+		})
+
+		await helper.saveSnippet('save_and_activate')
+		await helper.expectSuccessMessage(MESSAGES.SNIPPET_CREATED_AND_ACTIVATED)
+
+		await helper.navigateToSnippetsAdmin()
+
+		const snippetRow = page
+			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${snippetName}"))`)
+			.first()
+
+		await expect(snippetRow).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
+		await expect(snippetRow.locator(SELECTORS.SNIPPET_TOGGLE).first()).toBeChecked({ timeout: TIMEOUTS.DEFAULT })
+
+		await helper.cleanupSnippet(snippetName)
 	})
 
 	test('Can delete a snippet', async () => {

--- a/tests/e2e/code-snippets-list.spec.ts
+++ b/tests/e2e/code-snippets-list.spec.ts
@@ -132,4 +132,35 @@ test.describe('Code Snippets List Page Actions', () => {
 
 		expect(download.suggestedFilename()).toMatch(/\.json$/)
 	})
+
+	test('Can export multiple snippets from bulk actions', async ({ page }) => {
+		test.setTimeout(EXPORT_TEST_TIMEOUT_MS)
+		const secondSnippetName = SnippetsTestHelper.makeUniqueSnippetName()
+
+		await helper.createAndActivateSnippet({
+			name: secondSnippetName,
+			code: "add_filter('show_admin_bar', '__return_false');"
+		})
+		await helper.navigateToSnippetsAdmin()
+
+		const firstRow = page
+			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${snippetName}"))`)
+			.first()
+		const secondRow = page
+			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${secondSnippetName}"))`)
+			.first()
+
+		await firstRow.locator('input[name="checked[]"]').check({ force: true })
+		await secondRow.locator('input[name="checked[]"]').check({ force: true })
+		await page.locator('select[name="action"]').first().selectOption({ label: 'Export' })
+
+		const download = await Promise.all([
+			page.waitForEvent('download'),
+			page.locator('#doaction').click()
+		]).then(([downloadEvent]) => downloadEvent)
+
+		expect(download.suggestedFilename()).toBe('snippets.code-snippets.json')
+
+		await helper.cleanupSnippet(secondSnippetName)
+	})
 })

--- a/tests/e2e/code-snippets-list.spec.ts
+++ b/tests/e2e/code-snippets-list.spec.ts
@@ -163,4 +163,53 @@ test.describe('Code Snippets List Page Actions', () => {
 
 		await helper.cleanupSnippet(secondSnippetName)
 	})
+
+	test('Can download a single snippet from bulk actions', async ({ page }) => {
+		test.setTimeout(EXPORT_TEST_TIMEOUT_MS)
+		const snippetRow = page
+			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${snippetName}"))`)
+			.first()
+
+		await snippetRow.locator('input[name="checked[]"]').check({ force: true })
+		await page.locator('select[name="action"]').first().selectOption({ label: 'Download' })
+
+		const download = await Promise.all([
+			page.waitForEvent('download'),
+			page.locator('#doaction').click()
+		]).then(([downloadEvent]) => downloadEvent)
+
+		expect(download.suggestedFilename()).toMatch(/\.code-snippets\.php$/)
+	})
+
+	test('Can download multiple snippets from bulk actions as a zip archive', async ({ page }) => {
+		test.setTimeout(EXPORT_TEST_TIMEOUT_MS)
+		const secondSnippetName = SnippetsTestHelper.makeUniqueSnippetName('E2E Download CSS')
+
+		await SnippetsTestHelper.createSnippetViaCli({
+			name: secondSnippetName,
+			active: false,
+			type: 'css'
+		})
+		await helper.navigateToSnippetsAdmin()
+
+		const firstRow = page
+			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${snippetName}"))`)
+			.first()
+		const secondRow = page
+			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${secondSnippetName}"))`)
+			.first()
+
+		await firstRow.locator('input[name="checked[]"]').check({ force: true })
+		await secondRow.locator('input[name="checked[]"]').check({ force: true })
+		await page.locator('select[name="action"]').first().selectOption({ label: 'Download' })
+
+		const download = await Promise.all([
+			page.waitForEvent('download'),
+			page.locator('#doaction').click()
+		]).then(([downloadEvent]) => downloadEvent)
+
+		expect(download.suggestedFilename()).toBe('snippets.code-snippets.zip')
+
+		await helper.cleanupSnippet(secondSnippetName)
+	})
 })

--- a/tests/e2e/code-snippets-list.spec.ts
+++ b/tests/e2e/code-snippets-list.spec.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'fs'
 import { expect, test } from '@playwright/test'
 import { SnippetsTestHelper } from './helpers/SnippetsTestHelper'
 import { SELECTORS } from './helpers/constants'
+import type { Page } from '@playwright/test'
 
 test.describe('Code Snippets List Page Actions', () => {
 	let helper: SnippetsTestHelper
@@ -256,5 +258,128 @@ test.describe('Code Snippets List Page Actions', () => {
 			await helper.cleanupSnippet(firstScopedSnippetName)
 			await helper.cleanupSnippet(secondScopedSnippetName)
 		}
+	})
+
+	test('Bulk export stays scoped to the current page selection', async ({ page }) => {
+		test.setTimeout(EXPORT_TEST_TIMEOUT_MS)
+		const bulkScopeBaseName = 'E2E Bulk Scope Export'
+		const firstScopedSnippetName = SnippetsTestHelper.makeUniqueSnippetName(bulkScopeBaseName)
+		const secondScopedSnippetName = SnippetsTestHelper.makeUniqueSnippetName(bulkScopeBaseName)
+
+		await SnippetsTestHelper.setSnippetsPerPage(1)
+
+		try {
+			await helper.createAndActivateSnippet({
+				name: firstScopedSnippetName,
+				code: "add_filter('show_admin_bar', '__return_false');"
+			})
+			await helper.createAndActivateSnippet({
+				name: secondScopedSnippetName,
+				code: "add_filter('show_admin_bar', '__return_false');"
+			})
+			await helper.navigateToSnippetsAdmin()
+
+			await page.locator('#snippets_search').fill(bulkScopeBaseName)
+
+			// Select a row on page 1.
+			const firstPageRow = page.locator(SELECTORS.SNIPPET_ROW).first()
+			await expect(firstPageRow).toBeVisible()
+			await firstPageRow.locator('input[name="checked[]"]').check({ force: true })
+
+			// Navigate to page 2 - the page-1 selection should be cleared.
+			await page.locator('.next-page').first().click()
+
+			// Select the row on page 2 and export.
+			const secondPageRow = page.locator(SELECTORS.SNIPPET_ROW).first()
+			await expect(secondPageRow).toBeVisible()
+			await secondPageRow.locator('input[name="checked[]"]').check({ force: true })
+			await page.locator('select[name="action"]').first().selectOption({ label: 'Export' })
+
+			const download = await Promise.all([
+				page.waitForEvent('download'),
+				page.locator('#doaction').click()
+			]).then(([downloadEvent]) => downloadEvent)
+
+			// A single-snippet export (not a multi-snippet archive) confirms only the page-2
+			// snippet — not both — was included in the selection.
+			expect(download.suggestedFilename()).toMatch(/\.code-snippets\.json$/)
+			const downloadPath = await download.path()
+			if (!downloadPath) {
+				throw new Error('Download did not produce a local file path')
+			}
+			const parsed = <{ snippets: { name: string }[] }><unknown>JSON.parse(readFileSync(downloadPath, 'utf-8'))
+			expect(parsed.snippets).toHaveLength(1)
+		} finally {
+			await SnippetsTestHelper.resetSnippetsPerPage()
+			await helper.cleanupSnippet(firstScopedSnippetName)
+			await helper.cleanupSnippet(secondScopedSnippetName)
+		}
+	})
+})
+
+test.describe('Manage table Screen Options', () => {
+	let helper: SnippetsTestHelper
+	let snippetName: string
+
+	test.beforeEach(async ({ page }) => {
+		helper = new SnippetsTestHelper(page)
+		snippetName = SnippetsTestHelper.makeUniqueSnippetName('E2E Screen Options')
+		await helper.createAndActivateSnippet({
+			name: snippetName,
+			code: "add_filter('show_admin_bar', '__return_false');"
+		})
+		await helper.navigateToSnippetsAdmin()
+	})
+
+	test.afterEach(async () => {
+		await helper.cleanupSnippet(snippetName)
+	})
+
+	const openScreenOptions = async (page: Page) => {
+		const panel = page.locator('#adv-settings')
+		const isVisible = await panel.isVisible().catch(() => false)
+
+		if (!isVisible) {
+			await page.locator('#show-settings-link').click()
+			await expect(panel).toBeVisible()
+		}
+	}
+
+	test('Column visibility toggle hides and shows columns in real time', async ({ page }) => {
+		await openScreenOptions(page)
+
+		const descToggle = page.locator('#adv-settings input.hide-column-tog[value="desc"]')
+		await expect(descToggle).toBeVisible()
+
+		// Ensure Description column is initially visible.
+		await descToggle.check()
+		await expect(page.locator('.wp-list-table th.column-desc').first()).not.toHaveClass(/\bhidden\b/)
+
+		// Uncheck — column should disappear in real time.
+		await descToggle.uncheck()
+		await expect(page.locator('.wp-list-table th.column-desc').first()).toHaveClass(/\bhidden\b/)
+
+		// Re-check — column should reappear in real time.
+		await descToggle.check()
+		await expect(page.locator('.wp-list-table th.column-desc').first()).not.toHaveClass(/\bhidden\b/)
+	})
+
+	test('Truncation toggle applies and removes the truncation class in real time', async ({ page }) => {
+		await openScreenOptions(page)
+
+		const truncationToggle = page.locator('#snippets-table-truncate-row-values')
+		await expect(truncationToggle).toBeVisible()
+
+		// Enable truncation and verify the CSS class is applied.
+		await truncationToggle.check()
+		await expect(page.locator('.wp-list-table.truncate-row-values')).toBeVisible()
+
+		// Disable truncation and verify the CSS class is removed.
+		await truncationToggle.uncheck()
+		await expect(page.locator('.wp-list-table.truncate-row-values')).toBeHidden()
+
+		// Re-enable and verify restoration.
+		await truncationToggle.check()
+		await expect(page.locator('.wp-list-table.truncate-row-values')).toBeVisible()
 	})
 })

--- a/tests/e2e/code-snippets-list.spec.ts
+++ b/tests/e2e/code-snippets-list.spec.ts
@@ -212,4 +212,49 @@ test.describe('Code Snippets List Page Actions', () => {
 
 		await helper.cleanupSnippet(secondSnippetName)
 	})
+
+	test('Bulk download stays scoped to the current page selection', async ({ page }) => {
+		test.setTimeout(EXPORT_TEST_TIMEOUT_MS)
+		const bulkScopeBaseName = 'E2E Bulk Scope'
+		const firstScopedSnippetName = SnippetsTestHelper.makeUniqueSnippetName(bulkScopeBaseName)
+		const secondScopedSnippetName = SnippetsTestHelper.makeUniqueSnippetName(bulkScopeBaseName)
+
+		await SnippetsTestHelper.setSnippetsPerPage(1)
+
+		try {
+			await helper.createAndActivateSnippet({
+				name: firstScopedSnippetName,
+				code: "add_filter('show_admin_bar', '__return_false');"
+			})
+			await helper.createAndActivateSnippet({
+				name: secondScopedSnippetName,
+				code: "add_filter('show_admin_bar', '__return_false');"
+			})
+			await helper.navigateToSnippetsAdmin()
+
+			await page.locator('#snippets_search').fill(bulkScopeBaseName)
+
+			const firstPageRow = page.locator(SELECTORS.SNIPPET_ROW).first()
+			await expect(firstPageRow).toBeVisible()
+			await firstPageRow.locator('input[name="checked[]"]').check({ force: true })
+
+			await page.locator('.next-page').first().click()
+
+			const secondPageRow = page.locator(SELECTORS.SNIPPET_ROW).first()
+			await expect(secondPageRow).toBeVisible()
+			await secondPageRow.locator('input[name="checked[]"]').check({ force: true })
+			await page.locator('select[name="action"]').first().selectOption({ label: 'Download' })
+
+			const download = await Promise.all([
+				page.waitForEvent('download'),
+				page.locator('#doaction').click()
+			]).then(([downloadEvent]) => downloadEvent)
+
+			expect(download.suggestedFilename()).toMatch(/\.code-snippets\.php$/)
+		} finally {
+			await SnippetsTestHelper.resetSnippetsPerPage()
+			await helper.cleanupSnippet(firstScopedSnippetName)
+			await helper.cleanupSnippet(secondScopedSnippetName)
+		}
+	})
 })

--- a/tests/e2e/code-snippets-list.spec.ts
+++ b/tests/e2e/code-snippets-list.spec.ts
@@ -208,7 +208,7 @@ test.describe('Code Snippets List Page Actions', () => {
 			page.locator('#doaction').click()
 		]).then(([downloadEvent]) => downloadEvent)
 
-		expect(download.suggestedFilename()).toBe('snippets.code-snippets.zip')
+		expect(download.suggestedFilename()).toMatch(/^code-snippets-\d+\.zip$/)
 
 		await helper.cleanupSnippet(secondSnippetName)
 	})

--- a/tests/e2e/helpers/SnippetsTestHelper.ts
+++ b/tests/e2e/helpers/SnippetsTestHelper.ts
@@ -231,6 +231,13 @@ export class SnippetsTestHelper {
 	}
 
 	/**
+   * Filter the snippets table to a specific snippet name.
+   */
+	async filterSnippetsByName(snippetName: string): Promise<void> {
+		await this.page.fill(SELECTORS.SNIPPET_SEARCH_INPUT, snippetName)
+	}
+
+	/**
    * Navigate to frontend
    */
 	async navigateToFrontend(): Promise<void> {
@@ -325,6 +332,7 @@ export class SnippetsTestHelper {
 	async openSnippet(snippetName: string): Promise<void> {
 		await this.page.goto(URLS.SNIPPETS_ADMIN)
 		await this.page.waitForSelector(SELECTORS.SNIPPETS_TABLE, { timeout: TIMEOUTS.DEFAULT })
+		await this.filterSnippetsByName(snippetName)
 
 		const row = this.page.locator(SELECTORS.SNIPPET_ROW).filter({ hasText: snippetName }).first()
 		await expect(row).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
@@ -364,6 +372,7 @@ export class SnippetsTestHelper {
    */
 	async deleteSnippetFromList(snippetName: string): Promise<void> {
 		await this.navigateToSnippetsAdmin()
+		await this.filterSnippetsByName(snippetName)
 
 		const row = this.page
 			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${snippetName}"))`)
@@ -499,6 +508,7 @@ export class SnippetsTestHelper {
 
 		// Ensure activation is actually persisted by toggling from the list screen.
 		await this.navigateToSnippetsAdmin()
+		await this.filterSnippetsByName(options.name)
 		const row = this.page
 			.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK}:has-text("${options.name}"))`)
 			.first()

--- a/tests/e2e/helpers/SnippetsTestHelper.ts
+++ b/tests/e2e/helpers/SnippetsTestHelper.ts
@@ -59,6 +59,26 @@ export class SnippetsTestHelper {
 		await wpCli(['eval', php])
 	}
 
+	static async setSnippetsPerPage(perPage: number): Promise<void> {
+		const php = `
+			$user = get_user_by('login', 'admin');
+			$user_id = $user ? $user->ID : 1;
+			update_user_option($user_id, 'snippets_per_page', ${perPage});
+		`
+
+		await wpCli(['eval', php])
+	}
+
+	static async resetSnippetsPerPage(): Promise<void> {
+		const php = `
+			$user = get_user_by('login', 'admin');
+			$user_id = $user ? $user->ID : 1;
+			delete_user_option($user_id, 'snippets_per_page');
+		`
+
+		await wpCli(['eval', php])
+	}
+
 	static async createSnippetViaCli(options: CreateSnippetCliOptions): Promise<void> {
 		const type = options.type ?? 'php'
 		let scope = 'global'

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -10,6 +10,7 @@ export const SELECTORS = <const>{
 	SNIPPET_ROW: '.wp-list-table tbody tr',
 	SNIPPET_TOGGLE: 'input.switch',
 	SNIPPET_NAME_LINK: '.snippet-name',
+	SNIPPET_SEARCH_INPUT: '#snippets_search',
 
 	CLONE_ACTION: '.row-actions button:has-text("Clone")',
 	DELETE_ACTION: '.row-actions button:has-text("Trash")',

--- a/tests/phpunit/test-admin-bar.php
+++ b/tests/phpunit/test-admin-bar.php
@@ -322,6 +322,30 @@ class Admin_Bar_Test extends TestCase {
 	}
 
 	/**
+	 * Snippet listing links use the edit screen ID query arg.
+	 *
+	 * @return void
+	 */
+	public function test_snippet_listing_links_use_id_query_arg(): void {
+		$active = $this->create_snippet( 'QuickNav Edit Link Active', true );
+		$inactive = $this->create_snippet( 'QuickNav Edit Link Inactive', false );
+
+		$wp_admin_bar = $this->build_admin_bar();
+		$admin_bar = new Admin_Bar();
+		$admin_bar->register_nodes( $wp_admin_bar );
+
+		$active_node = $wp_admin_bar->get_node( 'code-snippets-snippet-' . $active->id );
+		$inactive_node = $wp_admin_bar->get_node( 'code-snippets-snippet-' . $inactive->id );
+
+		$this->assertNotNull( $active_node );
+		$this->assertNotNull( $inactive_node );
+		$this->assertStringContainsString( 'id=' . $active->id, $active_node->href );
+		$this->assertStringNotContainsString( 'edit=' . $active->id, $active_node->href );
+		$this->assertStringContainsString( 'id=' . $inactive->id, $inactive_node->href );
+		$this->assertStringNotContainsString( 'edit=' . $inactive->id, $inactive_node->href );
+	}
+
+	/**
 	 * Safe mode documentation link is registered under the Snippets root node.
 	 *
 	 * @return void

--- a/tests/phpunit/test-download-code.php
+++ b/tests/phpunit/test-download-code.php
@@ -56,9 +56,33 @@ class Download_Code_Test extends TestCase {
 
 		$download = Download_Code::build_snippet_download( $snippet );
 
-		$this->assertSame( 'my-html-snippet.code-snippets.php', $download['filename'] );
+		$this->assertSame( 'my-html-snippet.code-snippets.html', $download['filename'] );
+		$this->assertSame( 'text/html', $download['content_type'] );
+		$this->assertSame( "<p>Hello world</p>\n", $download['content'] );
+	}
+
+	/**
+	 * Downloading a single PHP snippet adds a PHP opening tag.
+	 *
+	 * @return void
+	 */
+	public function test_build_snippet_download_wraps_php_snippets(): void {
+		$snippet = save_snippet(
+			new Snippet(
+				[
+					'name'  => 'My PHP Snippet',
+					'code'  => 'echo "Hello world";',
+					'scope' => 'global',
+				]
+			)
+		);
+
+		$download = Download_Code::build_snippet_download( $snippet );
+
+		$this->assertSame( 'my-php-snippet.code-snippets.php', $download['filename'] );
 		$this->assertSame( 'text/php', $download['content_type'] );
-		$this->assertStringContainsString( '<p>Hello world</p>', $download['content'] );
+		$this->assertStringStartsWith( "<?php\n", $download['content'] );
+		$this->assertStringContainsString( 'echo "Hello world";', $download['content'] );
 	}
 
 	/**
@@ -97,7 +121,7 @@ class Download_Code_Test extends TestCase {
 		}
 
 		$this->assertIsArray( $download );
-		$this->assertSame( 'snippets.code-snippets.zip', $download['filename'] );
+		$this->assertMatchesRegularExpression( '/^code-snippets-\d+\.zip$/', $download['filename'] );
 		$this->assertSame( 'application/zip', $download['content_type'] );
 
 		$upload = wp_upload_bits( $download['filename'], null, $download['content'] );

--- a/tests/phpunit/test-download-code.php
+++ b/tests/phpunit/test-download-code.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Code_Snippets\Tests;
+
+use Code_Snippets\Migration\Export\Download_Code;
+use Code_Snippets\Model\Snippet;
+use WP_Error;
+use ZipArchive;
+use function Code_Snippets\code_snippets;
+use function Code_Snippets\save_snippet;
+
+/**
+ * Tests for snippet code downloads.
+ *
+ * @group export
+ */
+class Download_Code_Test extends TestCase {
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->clear_all_snippets();
+	}
+
+	/**
+	 * Clear all snippets from the database.
+	 *
+	 * @return void
+	 */
+	private function clear_all_snippets(): void {
+		global $wpdb;
+
+		$table_name = code_snippets()->db->get_table_name();
+		$wpdb->query( "TRUNCATE TABLE {$table_name}" );
+	}
+
+	/**
+	 * Downloading a single snippet uses the expected file extension and content type.
+	 *
+	 * @return void
+	 */
+	public function test_build_snippet_download_uses_type_based_filename(): void {
+		$snippet = save_snippet(
+			new Snippet(
+				[
+					'name'  => 'My HTML Snippet',
+					'code'  => '<p>Hello world</p>',
+					'scope' => 'content',
+				]
+			)
+		);
+
+		$download = Download_Code::build_snippet_download( $snippet );
+
+		$this->assertSame( 'my-html-snippet.code-snippets.php', $download['filename'] );
+		$this->assertSame( 'text/php', $download['content_type'] );
+		$this->assertStringContainsString( '<p>Hello world</p>', $download['content'] );
+	}
+
+	/**
+	 * Downloading multiple snippets builds a ZIP archive when ZipArchive is available.
+	 *
+	 * @return void
+	 */
+	public function test_build_archive_download_returns_zip_file(): void {
+		$php_snippet = save_snippet(
+			new Snippet(
+				[
+					'name'  => 'Bulk PHP Snippet',
+					'code'  => 'echo "One";',
+					'scope' => 'global',
+				]
+			)
+		);
+
+		$css_snippet = save_snippet(
+			new Snippet(
+				[
+					'name'  => 'Bulk CSS Snippet',
+					'code'  => 'body { color: red; }',
+					'scope' => 'site-css',
+				]
+			)
+		);
+
+		$download = Download_Code::build_archive_download( [ $php_snippet, $css_snippet ] );
+
+		if ( ! class_exists( ZipArchive::class ) ) {
+			$this->assertInstanceOf( WP_Error::class, $download );
+			$this->assertSame( 'zip_archive_unavailable', $download->get_error_code() );
+
+			return;
+		}
+
+		$this->assertIsArray( $download );
+		$this->assertSame( 'snippets.code-snippets.zip', $download['filename'] );
+		$this->assertSame( 'application/zip', $download['content_type'] );
+
+		$temp_file = wp_tempnam( $download['filename'] );
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.WP.AlternativeFunctions.file_system_operations_fwrite,WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Writing a local temporary archive for ZipArchive inspection.
+		$file_handle = fopen( $temp_file, 'wb' );
+		fwrite( $file_handle, $download['content'] );
+		fclose( $file_handle );
+		// phpcs:enable
+
+		$zip = new ZipArchive();
+		$this->assertTrue( $zip->open( $temp_file ) );
+		$this->assertStringContainsString( 'echo "One";', $zip->getFromName( 'bulk-php-snippet.code-snippets.php' ) );
+		$this->assertStringContainsString( 'body { color: red; }', $zip->getFromName( 'bulk-css-snippet.code-snippets.css' ) );
+		$zip->close();
+
+		wp_delete_file( $temp_file );
+	}
+}

--- a/tests/phpunit/test-download-code.php
+++ b/tests/phpunit/test-download-code.php
@@ -100,12 +100,8 @@ class Download_Code_Test extends TestCase {
 		$this->assertSame( 'snippets.code-snippets.zip', $download['filename'] );
 		$this->assertSame( 'application/zip', $download['content_type'] );
 
-		$temp_file = wp_tempnam( $download['filename'] );
-		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.WP.AlternativeFunctions.file_system_operations_fwrite,WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Writing a local temporary archive for ZipArchive inspection.
-		$file_handle = fopen( $temp_file, 'wb' );
-		fwrite( $file_handle, $download['content'] );
-		fclose( $file_handle );
-		// phpcs:enable
+		$upload = wp_upload_bits( $download['filename'], null, $download['content'] );
+		$temp_file = $upload['file'];
 
 		$zip = new ZipArchive();
 		$this->assertTrue( $zip->open( $temp_file ) );

--- a/tests/phpunit/test-edit-menu.php
+++ b/tests/phpunit/test-edit-menu.php
@@ -63,21 +63,14 @@ class Edit_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * The admin footer script disables the static Edit Snippet menu link.
+	 * The edit menu no longer injects inline JavaScript in the admin footer.
 	 *
 	 * @return void
 	 */
-	public function test_disable_menu_link_outputs_inline_script(): void {
+	public function test_edit_menu_does_not_use_footer_inline_script(): void {
 		$menu = new Edit_Menu();
 
-		ob_start();
-		$menu->disable_menu_link();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'aria-disabled', $output );
-		$this->assertStringContainsString( code_snippets()->get_menu_slug( 'edit' ), $output );
-		$this->assertStringContainsString( "style.cursor = 'pointer'", $output );
-		$this->assertStringContainsString( "removeAttribute( 'href' )", $output );
-		$this->assertStringContainsString( 'code_snippets_focus_editor', $output );
+		$this->assertFalse( has_action( 'admin_print_footer_scripts', [ $menu, 'disable_menu_link' ] ) );
+		$this->assertFalse( has_action( 'network_admin_print_footer_scripts', [ $menu, 'disable_menu_link' ] ) );
 	}
 }

--- a/tests/phpunit/test-edit-menu.php
+++ b/tests/phpunit/test-edit-menu.php
@@ -76,6 +76,7 @@ class Edit_Menu_Test extends TestCase {
 
 		$this->assertStringContainsString( 'aria-disabled', $output );
 		$this->assertStringContainsString( code_snippets()->get_menu_slug( 'edit' ), $output );
+		$this->assertStringContainsString( "style.cursor = 'pointer'", $output );
 		$this->assertStringContainsString( "removeAttribute( 'href' )", $output );
 		$this->assertStringContainsString( 'code_snippets_focus_editor', $output );
 	}

--- a/tests/phpunit/test-edit-menu.php
+++ b/tests/phpunit/test-edit-menu.php
@@ -44,6 +44,7 @@ class Edit_Menu_Test extends TestCase {
 
 		wp_set_current_user( self::$admin_user_id );
 		unset( $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] );
+		unset( $_GET['page'], $_GET['id'] );
 	}
 
 	/**
@@ -60,6 +61,46 @@ class Edit_Menu_Test extends TestCase {
 
 		$this->assertContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
 		$this->assertContains( code_snippets()->get_menu_slug( 'add' ), $submenu_slugs );
+	}
+
+	/**
+	 * Hide the edit submenu item outside the snippet edit screen.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_hide_menu_item_removes_edit_submenu_outside_edit_screen(): void {
+		$menu = new Edit_Menu();
+		$menu->register();
+
+		$_GET['page'] = code_snippets()->get_menu_slug();
+
+		$menu->maybe_hide_menu_item();
+
+		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
+		$submenu_slugs = array_column( $submenu, 2 );
+
+		$this->assertNotContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
+		$this->assertContains( code_snippets()->get_menu_slug( 'add' ), $submenu_slugs );
+	}
+
+	/**
+	 * Keep the edit submenu item visible while editing a specific snippet.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_hide_menu_item_keeps_edit_submenu_on_edit_screen(): void {
+		$menu = new Edit_Menu();
+		$menu->register();
+
+		$_GET['page'] = code_snippets()->get_menu_slug( 'edit' );
+		$_GET['id']   = '11';
+
+		$menu->maybe_hide_menu_item();
+
+		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
+		$submenu_slugs = array_column( $submenu, 2 );
+
+		$this->assertContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
 	}
 
 	/**

--- a/tests/phpunit/test-edit-menu.php
+++ b/tests/phpunit/test-edit-menu.php
@@ -43,8 +43,9 @@ class Edit_Menu_Test extends TestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$admin_user_id );
+		set_current_screen( 'toplevel_page_' . code_snippets()->get_menu_slug() );
 		unset( $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] );
-		unset( $_GET['page'], $_GET['id'] );
+		unset( $_GET['id'] );
 	}
 
 	/**
@@ -72,9 +73,7 @@ class Edit_Menu_Test extends TestCase {
 		$menu = new Edit_Menu();
 		$menu->register();
 
-		$_GET['page'] = code_snippets()->get_menu_slug();
-
-		$menu->maybe_hide_menu_item();
+		$menu->maybe_hide_menu_item( get_current_screen() );
 
 		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
 		$submenu_slugs = array_column( $submenu, 2 );
@@ -92,10 +91,17 @@ class Edit_Menu_Test extends TestCase {
 		$menu = new Edit_Menu();
 		$menu->register();
 
-		$_GET['page'] = code_snippets()->get_menu_slug( 'edit' );
-		$_GET['id']   = '11';
+		$screen = get_current_screen();
+		$hook = get_plugin_page_hookname(
+			code_snippets()->get_menu_slug( 'edit' ),
+			code_snippets()->get_menu_slug()
+		);
 
-		$menu->maybe_hide_menu_item();
+		$screen->id   = $hook;
+		$screen->base = $hook;
+		$_GET['id'] = '11';
+
+		$menu->maybe_hide_menu_item( $screen );
 
 		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
 		$submenu_slugs = array_column( $submenu, 2 );
@@ -113,5 +119,16 @@ class Edit_Menu_Test extends TestCase {
 
 		$this->assertFalse( has_action( 'admin_print_footer_scripts', [ $menu, 'disable_menu_link' ] ) );
 		$this->assertFalse( has_action( 'network_admin_print_footer_scripts', [ $menu, 'disable_menu_link' ] ) );
+	}
+
+	/**
+	 * The edit menu hides its submenu item using the current_screen hook.
+	 *
+	 * @return void
+	 */
+	public function test_edit_menu_uses_current_screen_to_hide_menu_item(): void {
+		$menu = new Edit_Menu();
+
+		$this->assertNotFalse( has_action( 'current_screen', [ $menu, 'maybe_hide_menu_item' ] ) );
 	}
 }

--- a/tests/phpunit/test-edit-menu.php
+++ b/tests/phpunit/test-edit-menu.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Code_Snippets\Tests;
+
+use Code_Snippets\Admin\Menus\Edit_Menu;
+use function Code_Snippets\code_snippets;
+
+/**
+ * Tests for the edit menu registration.
+ *
+ * @group admin-menu
+ */
+class Edit_Menu_Test extends TestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected static int $admin_user_id;
+
+	/**
+	 * Set up fixtures before any tests run.
+	 *
+	 * @param mixed $factory Factory object.
+	 *
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+	}
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_user_id );
+		unset( $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] );
+	}
+
+	/**
+	 * The edit submenu item is removed after registration.
+	 *
+	 * @return void
+	 */
+	public function test_register_hides_edit_submenu_item(): void {
+		$menu = new Edit_Menu();
+		$menu->register();
+
+		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
+		$submenu_slugs = array_column( $submenu, 2 );
+
+		$this->assertNotContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
+		$this->assertContains( code_snippets()->get_menu_slug( 'add' ), $submenu_slugs );
+	}
+}

--- a/tests/phpunit/test-edit-menu.php
+++ b/tests/phpunit/test-edit-menu.php
@@ -47,18 +47,36 @@ class Edit_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * The edit submenu item is removed after registration.
+	 * The edit submenu item remains registered so the page stays directly accessible.
 	 *
 	 * @return void
 	 */
-	public function test_register_hides_edit_submenu_item(): void {
+	public function test_register_keeps_edit_submenu_item(): void {
 		$menu = new Edit_Menu();
 		$menu->register();
 
 		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
 		$submenu_slugs = array_column( $submenu, 2 );
 
-		$this->assertNotContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
+		$this->assertContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
 		$this->assertContains( code_snippets()->get_menu_slug( 'add' ), $submenu_slugs );
+	}
+
+	/**
+	 * The admin footer script disables the static Edit Snippet menu link.
+	 *
+	 * @return void
+	 */
+	public function test_disable_menu_link_outputs_inline_script(): void {
+		$menu = new Edit_Menu();
+
+		ob_start();
+		$menu->disable_menu_link();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'aria-disabled', $output );
+		$this->assertStringContainsString( code_snippets()->get_menu_slug( 'edit' ), $output );
+		$this->assertStringContainsString( "removeAttribute( 'href' )", $output );
+		$this->assertStringContainsString( 'code_snippets_focus_editor', $output );
 	}
 }

--- a/tests/phpunit/test-flat-files-hooks.php
+++ b/tests/phpunit/test-flat-files-hooks.php
@@ -2,6 +2,10 @@
 
 namespace Code_Snippets\Tests;
 
+use Code_Snippets\Flat_Files\Handler_Registry;
+use Code_Snippets\Flat_Files\Interfaces\Filesystem_Adapter;
+use Code_Snippets\Flat_Files\Interfaces\Snippet_Config_Repository;
+use Code_Snippets\Flat_Files\Snippet_Files;
 use Code_Snippets\Model\Snippet;
 use function Code_Snippets\save_snippet;
 use function Code_Snippets\update_snippet_fields;
@@ -12,6 +16,22 @@ use function Code_Snippets\update_snippet_fields;
  * @group flat-files
  */
 class Flat_Files_Hooks_Test extends TestCase {
+	private function build_snippet_files( Filesystem_Adapter $fs ): Snippet_Files {
+		$config_repo = new class() implements Snippet_Config_Repository {
+			public function load( string $base_dir ): array {
+				return [];
+			}
+
+			public function save( string $base_dir, array $active_snippets ): void {
+			}
+
+			public function update( string $base_dir, Snippet $snippet, ?bool $remove = false ): void {
+			}
+		};
+
+		return new Snippet_Files( new Handler_Registry( [] ), $fs, $config_repo );
+	}
+
 	public function test_update_snippet_fields_triggers_update_action_with_snippet_object() {
 		$snippet = new Snippet(
 			[
@@ -40,5 +60,64 @@ class Flat_Files_Hooks_Test extends TestCase {
 
 		$this->assertInstanceOf( Snippet::class, $observed );
 		$this->assertSame( $saved->id, $observed->id );
+	}
+
+	public function test_add_option_sync_only_runs_for_active_shared_network_snippets(): void {
+		$writes = [];
+		$fs = new class( $writes ) implements Filesystem_Adapter {
+			private array $writes;
+
+			public function __construct( array &$writes ) {
+				$this->writes = &$writes;
+			}
+
+			public function put_contents( string $path, string $contents, $chmod ): bool {
+				$this->writes[] = $path;
+				return true;
+			}
+
+			public function exists( string $path ): bool {
+				return false;
+			}
+
+			public function delete( string $file, bool $recursive = false, $type = false ): bool {
+				return true;
+			}
+
+			public function is_dir( string $path ): bool {
+				return true;
+			}
+
+			public function mkdir( string $path, $chmod ): bool {
+				return true;
+			}
+
+			public function rmdir( string $path, bool $recursive = false ): bool {
+				return true;
+			}
+
+			public function chmod( string $path, $chmod ): bool {
+				return true;
+			}
+
+			public function is_writable( string $path ): bool {
+				return true;
+			}
+		};
+
+		$snippet_files = $this->build_snippet_files( $fs );
+		$snippet_files->sync_active_shared_network_snippets_add( 'litespeed.some_option', [ 1 ] );
+
+		$this->assertSame( [], $writes );
+
+		$snippet_files->sync_active_shared_network_snippets_add( 'active_shared_network_snippets', [ 1 ] );
+
+		$this->assertNotEmpty( $writes );
+	}
+
+	public function test_get_hashed_table_name_uses_wordpress_hash_when_available(): void {
+		$table_name = 'wp_code_snippets';
+
+		$this->assertSame( wp_hash( $table_name ), Snippet_Files::get_hashed_table_name( $table_name ) );
 	}
 }

--- a/tests/phpunit/test-flat-files-hooks.php
+++ b/tests/phpunit/test-flat-files-hooks.php
@@ -16,15 +16,48 @@ use function Code_Snippets\update_snippet_fields;
  * @group flat-files
  */
 class Flat_Files_Hooks_Test extends TestCase {
+
+	/**
+	 * Build a Snippet_Files instance with a stub filesystem adapter.
+	 *
+	 * @param Filesystem_Adapter $fs Filesystem adapter.
+	 *
+	 * @return Snippet_Files
+	 */
 	private function build_snippet_files( Filesystem_Adapter $fs ): Snippet_Files {
 		$config_repo = new class() implements Snippet_Config_Repository {
+
+			/**
+			 * Load a list of active snippets.
+			 *
+			 * @param string $base_dir Base directory.
+			 *
+			 * @return array<string, mixed>[]
+			 */
 			public function load( string $base_dir ): array {
 				return [];
 			}
 
+			/**
+			 * Save the active snippets list.
+			 *
+			 * @param string $base_dir        Base directory.
+			 * @param array  $active_snippets Active snippets.
+			 *
+			 * @return void
+			 */
 			public function save( string $base_dir, array $active_snippets ): void {
 			}
 
+			/**
+			 * Update a snippet entry in the active config.
+			 *
+			 * @param string    $base_dir Base directory.
+			 * @param Snippet   $snippet  Snippet.
+			 * @param bool|null $remove   Whether to remove the snippet.
+			 *
+			 * @return void
+			 */
 			public function update( string $base_dir, Snippet $snippet, ?bool $remove = false ): void {
 			}
 		};
@@ -32,6 +65,11 @@ class Flat_Files_Hooks_Test extends TestCase {
 		return new Snippet_Files( new Handler_Registry( [] ), $fs, $config_repo );
 	}
 
+	/**
+	 * Ensure update_snippet_fields triggers the update action with a Snippet object.
+	 *
+	 * @return void
+	 */
 	public function test_update_snippet_fields_triggers_update_action_with_snippet_object() {
 		$snippet = new Snippet(
 			[
@@ -62,44 +100,123 @@ class Flat_Files_Hooks_Test extends TestCase {
 		$this->assertSame( $saved->id, $observed->id );
 	}
 
+	/**
+	 * Ensure add_option sync only runs for the active_shared_network_snippets option.
+	 *
+	 * @return void
+	 */
 	public function test_add_option_sync_only_runs_for_active_shared_network_snippets(): void {
 		$writes = [];
 		$fs = new class( $writes ) implements Filesystem_Adapter {
+
+			/**
+			 * Paths written via put_contents().
+			 *
+			 * @var array<int, string>
+			 */
 			private array $writes;
 
+			/**
+			 * Constructor.
+			 *
+			 * @param array<int, string> $writes Write sink.
+			 */
 			public function __construct( array &$writes ) {
 				$this->writes = &$writes;
 			}
 
+			/**
+			 * Write file contents.
+			 *
+			 * @param string $path     Path.
+			 * @param string $contents Contents.
+			 * @param mixed  $chmod    Chmod mode.
+			 *
+			 * @return bool
+			 */
 			public function put_contents( string $path, string $contents, $chmod ): bool {
 				$this->writes[] = $path;
 				return true;
 			}
 
+			/**
+			 * Whether a path exists.
+			 *
+			 * @param string $path Path.
+			 *
+			 * @return bool
+			 */
 			public function exists( string $path ): bool {
 				return false;
 			}
 
+			/**
+			 * Delete a path.
+			 *
+			 * @param string $file      File path.
+			 * @param bool   $recursive Recursive delete.
+			 * @param mixed  $type      Delete type.
+			 *
+			 * @return bool
+			 */
 			public function delete( string $file, bool $recursive = false, $type = false ): bool {
 				return true;
 			}
 
+			/**
+			 * Whether a path is a directory.
+			 *
+			 * @param string $path Path.
+			 *
+			 * @return bool
+			 */
 			public function is_dir( string $path ): bool {
 				return true;
 			}
 
+			/**
+			 * Create a directory.
+			 *
+			 * @param string $path  Path.
+			 * @param mixed  $chmod Chmod mode.
+			 *
+			 * @return bool
+			 */
 			public function mkdir( string $path, $chmod ): bool {
 				return true;
 			}
 
+			/**
+			 * Remove a directory.
+			 *
+			 * @param string $path      Path.
+			 * @param bool   $recursive Recursive remove.
+			 *
+			 * @return bool
+			 */
 			public function rmdir( string $path, bool $recursive = false ): bool {
 				return true;
 			}
 
+			/**
+			 * Change permissions.
+			 *
+			 * @param string $path  Path.
+			 * @param mixed  $chmod Chmod mode.
+			 *
+			 * @return bool
+			 */
 			public function chmod( string $path, $chmod ): bool {
 				return true;
 			}
 
+			/**
+			 * Whether a path is writable.
+			 *
+			 * @param string $path Path.
+			 *
+			 * @return bool
+			 */
 			public function is_writable( string $path ): bool {
 				return true;
 			}
@@ -115,6 +232,11 @@ class Flat_Files_Hooks_Test extends TestCase {
 		$this->assertNotEmpty( $writes );
 	}
 
+	/**
+	 * Ensure get_hashed_table_name uses WordPress hashing when available.
+	 *
+	 * @return void
+	 */
 	public function test_get_hashed_table_name_uses_wordpress_hash_when_available(): void {
 		$table_name = 'wp_code_snippets';
 

--- a/tests/phpunit/test-manage-menu.php
+++ b/tests/phpunit/test-manage-menu.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Code_Snippets\Tests;
+
+use Code_Snippets\Admin\Menus\Manage_Menu;
+use function Code_Snippets\code_snippets;
+
+/**
+ * Tests for the manage menu registration.
+ *
+ * @group admin-menu
+ */
+class Manage_Menu_Test extends TestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected static int $admin_user_id;
+
+	/**
+	 * Set up fixtures before any tests run.
+	 *
+	 * @param mixed $factory Factory object.
+	 *
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_user_id );
+		set_current_screen( 'toplevel_page_' . code_snippets()->get_menu_slug() );
+	}
+
+	/**
+	 * The manage screen registers a Columns section in Screen Options.
+	 *
+	 * @return void
+	 */
+	public function test_load_registers_screen_option_columns(): void {
+		$menu = new Manage_Menu();
+		$menu->load();
+
+		$columns = get_column_headers( get_current_screen() );
+
+		$this->assertSame( 'Columns', $columns['_title'] );
+		$this->assertSame( 'Description', $columns['desc'] );
+		$this->assertSame( 'Modified', $columns['date'] );
+	}
+
+	/**
+	 * Hidden columns are localized for the manage table app.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_assets_localizes_hidden_columns(): void {
+		$screen = get_current_screen();
+		update_user_option( self::$admin_user_id, 'manage' . $screen->id . 'columnshidden', array( 'desc', 'date' ) );
+
+		$menu = new Manage_Menu();
+		$menu->enqueue_assets();
+
+		$data = wp_scripts()->get_data( Manage_Menu::JS_HANDLE, 'data' );
+
+		$this->assertIsString( $data );
+		$this->assertStringContainsString( '"hiddenColumns":["desc","date"]', $data );
+	}
+}

--- a/tests/phpunit/test-manage-menu.php
+++ b/tests/phpunit/test-manage-menu.php
@@ -44,8 +44,16 @@ class Manage_Menu_Test extends TestCase {
 
 		wp_set_current_user( self::$admin_user_id );
 		set_current_screen( 'toplevel_page_' . code_snippets()->get_menu_slug() );
+		remove_all_filters( 'manage_' . get_current_screen()->id . '_columns' );
+		remove_all_filters( 'screen_settings' );
 		delete_user_option( self::$admin_user_id, 'snippets_table_truncate_row_values' );
-		unset( $_POST['wp_screen_options'], $_POST['screenoptionnonce'], $_POST['snippets_table_truncate_row_values'], $_REQUEST['page'] );
+		unset(
+			$_POST['wp_screen_options'],
+			$_POST['screenoptionnonce'],
+			$_POST['snippets_table_truncate_row_values'],
+			$_REQUEST['page'],
+			$_REQUEST['subpage']
+		);
 	}
 
 	/**
@@ -95,7 +103,38 @@ class Manage_Menu_Test extends TestCase {
 		$output = $menu->render_screen_settings( '', get_current_screen() );
 
 		$this->assertStringContainsString( 'snippets-table-truncate-row-values', $output );
-		$this->assertStringContainsString( 'Truncate long row values', $output );
+		$this->assertStringContainsString( 'Truncate long snippet names and descriptions', $output );
+	}
+
+	/**
+	 * The Community Cloud view does not render snippet-only Screen Options controls.
+	 *
+	 * @return void
+	 */
+	public function test_render_screen_settings_skips_truncation_toggle_on_cloud_community_view(): void {
+		$_REQUEST['subpage'] = 'cloud-community';
+
+		$menu = new Manage_Menu();
+		$output = $menu->render_screen_settings( '', get_current_screen() );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * The Community Cloud view does not register snippet table columns in Screen Options.
+	 *
+	 * @return void
+	 */
+	public function test_load_skips_screen_option_columns_on_cloud_community_view(): void {
+		$_REQUEST['subpage'] = 'cloud-community';
+
+		$menu = new Manage_Menu();
+		$menu->load();
+
+		$screen = get_current_screen();
+
+		$this->assertFalse( has_filter( "manage_{$screen->id}_columns", array( $menu, 'get_screen_columns' ) ) );
+		$this->assertFalse( has_filter( 'screen_settings', array( $menu, 'render_screen_settings' ) ) );
 	}
 
 	/**

--- a/tests/phpunit/test-manage-menu.php
+++ b/tests/phpunit/test-manage-menu.php
@@ -49,6 +49,9 @@ class Manage_Menu_Test extends TestCase {
 		delete_user_option( self::$admin_user_id, 'snippets_table_truncate_row_values' );
 		unset(
 			$_POST['wp_screen_options'],
+			$_POST['code_snippets_action'],
+			$_POST['code_snippets_bulk_download_nonce'],
+			$_POST['snippets'],
 			$_POST['screenoptionnonce'],
 			$_POST['snippets_table_truncate_row_values'],
 			$_REQUEST['page'],
@@ -90,6 +93,8 @@ class Manage_Menu_Test extends TestCase {
 		$this->assertIsString( $data );
 		$this->assertStringContainsString( '"hiddenColumns":["desc","date"]', $data );
 		$this->assertStringContainsString( '"truncateRowValues":"0"', $data );
+		$this->assertStringContainsString( '"bulkDownloadNonce":"', $data );
+		$this->assertStringContainsString( '"supportsZipDownloads":', $data );
 	}
 
 	/**

--- a/tests/phpunit/test-manage-menu.php
+++ b/tests/phpunit/test-manage-menu.php
@@ -44,6 +44,8 @@ class Manage_Menu_Test extends TestCase {
 
 		wp_set_current_user( self::$admin_user_id );
 		set_current_screen( 'toplevel_page_' . code_snippets()->get_menu_slug() );
+		delete_user_option( self::$admin_user_id, 'snippets_table_truncate_row_values' );
+		unset( $_POST['wp_screen_options'], $_POST['screenoptionnonce'], $_POST['snippets_table_truncate_row_values'], $_REQUEST['page'] );
 	}
 
 	/**
@@ -70,6 +72,7 @@ class Manage_Menu_Test extends TestCase {
 	public function test_enqueue_assets_localizes_hidden_columns(): void {
 		$screen = get_current_screen();
 		update_user_option( self::$admin_user_id, 'manage' . $screen->id . 'columnshidden', array( 'desc', 'date' ) );
+		update_user_option( self::$admin_user_id, 'snippets_table_truncate_row_values', 0 );
 
 		$menu = new Manage_Menu();
 		$menu->enqueue_assets();
@@ -78,5 +81,44 @@ class Manage_Menu_Test extends TestCase {
 
 		$this->assertIsString( $data );
 		$this->assertStringContainsString( '"hiddenColumns":["desc","date"]', $data );
+		$this->assertStringContainsString( '"truncateRowValues":"0"', $data );
+	}
+
+	/**
+	 * The manage screen renders a truncation toggle in Screen Options.
+	 *
+	 * @return void
+	 */
+	public function test_render_screen_settings_adds_truncation_toggle(): void {
+		$menu = new Manage_Menu();
+
+		$output = $menu->render_screen_settings( '', get_current_screen() );
+
+		$this->assertStringContainsString( 'snippets-table-truncate-row-values', $output );
+		$this->assertStringContainsString( 'Truncate long row values', $output );
+	}
+
+	/**
+	 * The truncation preference is saved from the Screen Options form.
+	 *
+	 * @return void
+	 */
+	public function test_save_truncation_preference_updates_user_option(): void {
+		$_REQUEST['page'] = code_snippets()->get_menu_slug();
+		$_POST['wp_screen_options'] = array(
+			'option' => 'snippets_per_page',
+			'value'  => '20',
+		);
+		$_POST['screenoptionnonce'] = wp_create_nonce( 'screen-options-nonce' );
+
+		$menu = new Manage_Menu();
+		$menu->save_truncation_preference();
+
+		$this->assertFalse( (bool) get_user_option( 'snippets_table_truncate_row_values', self::$admin_user_id ) );
+
+		$_POST['snippets_table_truncate_row_values'] = '1';
+		$menu->save_truncation_preference();
+
+		$this->assertTrue( (bool) get_user_option( 'snippets_table_truncate_row_values', self::$admin_user_id ) );
 	}
 }

--- a/tests/phpunit/test-manage-menu.php
+++ b/tests/phpunit/test-manage-menu.php
@@ -171,6 +171,28 @@ class Manage_Menu_Test extends TestCase {
 	}
 
 	/**
+	 * The Community Cloud screen does not overwrite the snippets-table truncation preference.
+	 *
+	 * @return void
+	 */
+	public function test_save_truncation_preference_ignores_cloud_community_view(): void {
+		update_user_option( self::$admin_user_id, 'snippets_table_truncate_row_values', 1 );
+
+		$_REQUEST['page'] = code_snippets()->get_menu_slug();
+		$_REQUEST['subpage'] = 'cloud-community';
+		$_POST['wp_screen_options'] = array(
+			'option' => 'snippets_per_page',
+			'value'  => '20',
+		);
+		$_POST['screenoptionnonce'] = wp_create_nonce( 'screen-options-nonce' );
+
+		$menu = new Manage_Menu();
+		$menu->save_truncation_preference();
+
+		$this->assertTrue( (bool) get_user_option( 'snippets_table_truncate_row_values', self::$admin_user_id ) );
+	}
+
+	/**
 	 * Subsite admins cannot request downloads from the network snippets table.
 	 *
 	 * @return void

--- a/tests/phpunit/test-manage-menu.php
+++ b/tests/phpunit/test-manage-menu.php
@@ -147,6 +147,23 @@ class Manage_Menu_Test extends TestCase {
 	}
 
 	/**
+	 * The Community Cloud view still registers the shared pagination Screen Option.
+	 *
+	 * @return void
+	 */
+	public function test_load_registers_per_page_screen_option_on_cloud_community_view(): void {
+		$_REQUEST['subpage'] = 'cloud-community';
+
+		$menu = new Manage_Menu();
+		$menu->load();
+
+		$screen = get_current_screen();
+
+		$this->assertSame( 'snippets_per_page', $screen->get_option( 'per_page', 'option' ) );
+		$this->assertSame( 100, $screen->get_option( 'per_page', 'default' ) );
+	}
+
+	/**
 	 * The truncation preference is saved from the Screen Options form.
 	 *
 	 * @return void

--- a/tests/phpunit/test-manage-menu.php
+++ b/tests/phpunit/test-manage-menu.php
@@ -3,7 +3,11 @@
 namespace Code_Snippets\Tests;
 
 use Code_Snippets\Admin\Menus\Manage_Menu;
+use Code_Snippets\Model\Snippet;
+use ReflectionMethod;
+use WP_Error;
 use function Code_Snippets\code_snippets;
+use function Code_Snippets\save_snippet;
 
 /**
  * Tests for the manage menu registration.
@@ -164,5 +168,44 @@ class Manage_Menu_Test extends TestCase {
 		$menu->save_truncation_preference();
 
 		$this->assertTrue( (bool) get_user_option( 'snippets_table_truncate_row_values', self::$admin_user_id ) );
+	}
+
+	/**
+	 * Subsite admins cannot request downloads from the network snippets table.
+	 *
+	 * @return void
+	 */
+	public function test_network_bulk_download_requires_network_cap(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Network snippet downloads only apply on multisite.' );
+		}
+
+		$snippet = save_snippet(
+			new Snippet(
+				array(
+					'name'    => 'Network Download Fixture',
+					'code'    => '<?php echo "network";',
+					'scope'   => 'global',
+					'network' => true,
+				)
+			)
+		);
+
+		$_POST['snippets'] = wp_json_encode(
+			array(
+				array(
+					'id'      => $snippet->id,
+					'network' => true,
+				),
+			)
+		);
+
+		$menu = new Manage_Menu();
+		$method = new ReflectionMethod( $menu, 'get_requested_download_snippets' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $menu );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'code_snippets_forbidden_network_download', $result->get_error_code() );
 	}
 }

--- a/tests/phpunit/test-rest-api-cloud.php
+++ b/tests/phpunit/test-rest-api-cloud.php
@@ -179,6 +179,28 @@ class REST_API_Cloud_Test extends TestCase {
 	}
 
 	/**
+	 * Screen Options values above the cloud API limit are capped before the request is sent.
+	 *
+	 * @return void
+	 */
+	public function test_get_items_caps_snippets_per_page_user_option_at_one_hundred(): void {
+		update_user_option( self::$admin_user_id, 'snippets_per_page', 250 );
+
+		$response = $this->make_request(
+			[
+				'query' => 'test',
+				'page'  => 2,
+			]
+		);
+
+		parse_str( (string) wp_parse_url( $this->requested_url, PHP_URL_QUERY ), $query_args );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '100', $query_args['per_page'] ?? null );
+		$this->assertSame( '1', $query_args['page'] ?? null );
+	}
+
+	/**
 	 * Explicit per_page requests override the snippets Screen Options value.
 	 *
 	 * @return void

--- a/tests/phpunit/test-rest-api-cloud.php
+++ b/tests/phpunit/test-rest-api-cloud.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Code_Snippets\Tests;
+
+use WP_REST_Request;
+
+/**
+ * Tests for the Cloud REST API endpoint.
+ *
+ * @group rest-api
+ */
+class REST_API_Cloud_Test extends TestCase {
+
+	/**
+	 * Default per-page value used when none is configured.
+	 */
+	private const DEFAULT_PER_PAGE = 10;
+
+	/**
+	 * REST API namespace and base route.
+	 *
+	 * @var string
+	 */
+	protected string $endpoint = '/code-snippets/v1/cloud';
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected static int $admin_user_id;
+
+	/**
+	 * Most recent outbound cloud search URL.
+	 *
+	 * @var string
+	 */
+	private string $requested_url = '';
+
+	/**
+	 * Set up fixtures before any tests run.
+	 *
+	 * @param mixed $factory Factory object.
+	 *
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+	}
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_user_id );
+		$this->requested_url = '';
+		delete_user_option( self::$admin_user_id, 'snippets_per_page' );
+		add_filter( 'pre_http_request', [ $this, 'mock_cloud_search_request' ], 10, 3 );
+	}
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', [ $this, 'mock_cloud_search_request' ], 10 );
+		delete_user_option( self::$admin_user_id, 'snippets_per_page' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Mock the outbound cloud search request.
+	 *
+	 * @param mixed        $preempt     Existing preempted value.
+	 * @param array<mixed> $parsed_args Parsed HTTP request arguments.
+	 * @param string       $url         Requested URL.
+	 *
+	 * @return mixed
+	 */
+	public function mock_cloud_search_request( $preempt, array $parsed_args, string $url ) {
+		if ( false === strpos( $url, 'public/search' ) ) {
+			return $preempt;
+		}
+
+		$this->requested_url = $url;
+
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
+
+		$per_page = isset( $query_args['per_page'] ) ? (int) $query_args['per_page'] : self::DEFAULT_PER_PAGE;
+		$page = isset( $query_args['page'] ) ? (int) $query_args['page'] : 0;
+		$total_items = 12;
+		$total_pages = (int) ceil( $total_items / max( 1, $per_page ) );
+		$items_to_return = min( $per_page, $total_items );
+
+		$snippets = [];
+
+		for ( $index = 0; $index < $items_to_return; $index++ ) {
+			$snippets[] = [
+				'id'          => ( $page * $per_page ) + $index + 1,
+				'name'        => 'Cloud Snippet ' . ( $index + 1 ),
+				'description' => 'Test description',
+				'code'        => '<?php echo "test";',
+				'tags'        => [],
+				'scope'       => 'global',
+				'status'      => 4,
+				'codevault'   => 'General',
+				'vote_count'  => '0',
+				'updated'     => '2026-03-10 12:00:00',
+			];
+		}
+
+		return [
+			'headers'  => [],
+			'body'     => wp_json_encode(
+				[
+					'data' => $snippets,
+					'meta' => [
+						'total'       => $total_items,
+						'total_pages' => $total_pages,
+						'page'        => $page + 1,
+					],
+				]
+			),
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'cookies'  => [],
+		];
+	}
+
+	/**
+	 * Make a REST API request to the cloud endpoint.
+	 *
+	 * @param array<string, bool|int|string> $params Request params.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	private function make_request( array $params ) {
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * The cloud REST endpoint uses the snippets Screen Options value when per_page is omitted.
+	 *
+	 * @return void
+	 */
+	public function test_get_items_uses_snippets_per_page_user_option(): void {
+		update_user_option( self::$admin_user_id, 'snippets_per_page', 7 );
+
+		$response = $this->make_request(
+			[
+				'query' => 'test',
+				'page'  => 2,
+			]
+		);
+
+		parse_str( (string) wp_parse_url( $this->requested_url, PHP_URL_QUERY ), $query_args );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '7', $query_args['per_page'] ?? null );
+		$this->assertSame( '1', $query_args['page'] ?? null );
+	}
+
+	/**
+	 * Explicit per_page requests override the snippets Screen Options value.
+	 *
+	 * @return void
+	 */
+	public function test_get_items_respects_explicit_per_page_request(): void {
+		update_user_option( self::$admin_user_id, 'snippets_per_page', 7 );
+
+		$response = $this->make_request(
+			[
+				'query'    => 'test',
+				'page'     => 2,
+				'per_page' => 3,
+			]
+		);
+
+		parse_str( (string) wp_parse_url( $this->requested_url, PHP_URL_QUERY ), $query_args );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '3', $query_args['per_page'] ?? null );
+		$this->assertSame( '1', $query_args['page'] ?? null );
+	}
+}

--- a/tests/phpunit/test-rest-api-snippets.php
+++ b/tests/phpunit/test-rest-api-snippets.php
@@ -110,6 +110,26 @@ class REST_API_Snippets_Test extends TestCase {
 	}
 
 	/**
+	 * Helper method to make a writable REST API request.
+	 *
+	 * @param string $method   HTTP method.
+	 * @param string $endpoint Endpoint to request.
+	 * @param array  $params   Request params.
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function make_mutating_request( string $method, string $endpoint, array $params ): array {
+		$request = new WP_REST_Request( $method, $endpoint );
+
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		$response = rest_do_request( $request );
+		return rest_get_server()->response_to_data( $response, false );
+	}
+
+	/**
 	 * Test that we can retrieve all snippets without pagination.
 	 */
 	public function test_get_all_snippets_without_pagination() {
@@ -343,5 +363,31 @@ class REST_API_Snippets_Test extends TestCase {
 		$loaded = get_snippet( $saved->id );
 
 		$this->assertSame( 'Persisted description text', $loaded->desc );
+	}
+
+	/**
+	 * Test that activation failures return the PHP error and stack trace while keeping the snippet saved.
+	 */
+	public function test_create_active_snippet_returns_runtime_error_details() {
+		$response = $this->make_mutating_request(
+			'POST',
+			"/{$this->namespace}/{$this->base_route}",
+			[
+				'name'    => 'Activation Error Fixture',
+				'code'    => 'function code_snippets_build_tags_array() {}',
+				'scope'   => 'global',
+				'active'  => true,
+				'network' => false,
+			]
+		);
+
+		$this->assertArrayHasKey( 'id', $response );
+		$this->assertGreaterThan( 0, $response['id'] );
+		$this->assertFalse( $response['active'] );
+		$this->assertIsArray( $response['code_error'] );
+		$this->assertStringContainsString( 'Cannot redeclare', $response['code_error'][0] );
+		$this->assertArrayHasKey( 'code_error_trace', $response );
+		$this->assertIsString( $response['code_error_trace'] );
+		$this->assertNotSame( '', $response['code_error_trace'] );
 	}
 }

--- a/tests/phpunit/test-rest-api-snippets.php
+++ b/tests/phpunit/test-rest-api-snippets.php
@@ -5,6 +5,7 @@ namespace Code_Snippets\Tests;
 use Code_Snippets\Model\Snippet;
 use WP_REST_Request;
 use function Code_Snippets\code_snippets;
+use function Code_Snippets\get_snippet;
 use function Code_Snippets\save_snippet;
 
 /**
@@ -318,5 +319,29 @@ class REST_API_Snippets_Test extends TestCase {
 		$this->assertIsString( $snippet['code'] );
 		$this->assertIsBool( $snippet['active'] );
 		$this->assertIsArray( $snippet['tags'] );
+	}
+
+	/**
+	 * Test that the snippet description is loaded from the database.
+	 */
+	public function test_snippet_description_is_loaded_from_database() {
+		$snippet = new Snippet(
+			[
+				'name'   => 'Description Fixture',
+				'desc'   => 'Persisted description text',
+				'code'   => '// Description fixture',
+				'scope'  => 'global',
+				'active' => false,
+			]
+		);
+
+		$saved = save_snippet( $snippet );
+
+		$this->assertInstanceOf( Snippet::class, $saved );
+		$this->assertGreaterThan( 0, $saved->id );
+
+		$loaded = get_snippet( $saved->id );
+
+		$this->assertSame( 'Persisted description text', $loaded->desc );
 	}
 }


### PR DESCRIPTION
## Summary

This branch fixes the beta issues reported for Code Snippets and includes a set of follow-up admin usability improvements that were discovered while validating those fixes.

## Included Fixes

### Snippet editor and snippet data
- Restored snippet description rendering in both:
  - the snippet editor view
  - the All Snippets table
- Fixed `Save and Activate` for brand new snippets so activation works reliably on the first save.
- Fixed activation failure handling for snippets with PHP errors:
  - activation does not silently fail
  - the error notice includes the single-line PHP error message and an expandable stack trace
- Added shared notice styling for traced activation errors, including horizontal scrolling for long stack traces.
- Removed the `cs-back` back link from the editor.

### Admin navigation fixes
- Fixed admin bar snippet links to use the correct `id` query parameter.
- Changed the `Edit Snippet` sidebar item so it no longer navigates away from the current page:
  - clicking it focuses the CodeMirror editor

### Export and download fixes
- Fixed bulk export so selected snippets can be exported again as JSON for re-import.
- Kept `Export` and `Download` as separate actions:
  - `Export` produces importable JSON
  - `Download` produces raw snippet files
- Added bulk-only `Download` action for snippet code:
  - single selection downloads as an individual file based on snippet type
  - multiple selections download as a ZIP archive when `ZipArchive` is available
- Adjusted the bulk action UI so:
  - `Apply` is disabled by default and while `Bulk actions` is selected
  - `Apply` enables when a real action is selected

### Flat Files compatibility
- Fixed the Flat Files + LiteSpeed Cache fatal by preventing early bootstrap code from calling unavailable WordPress functions.

## Manage Screen Improvements

### Screen Options
- Added Screen Options support for choosing visible columns on the All Snippets table.
- Added a `Table Options` section for snippets table behavior with a toggle for truncating long row values.
- Restricted Screen Options so:
  - `snippets` view shows `Table Options`, `Columns`, and `Pagination`
  - `cloud-community` shows only `Pagination`

### Table behavior and markup
- Fixed sortable header markup/classes to match WordPress core sorted column behavior.

### Community Cloud pagination
- Applied the Screen Options pagination setting to Community Cloud requests passing `per_page` through the local REST layer and outbound cloud API request.
- Capped cloud `per_page` at `100` even if the user’s screen option is higher (avoids api error messages)