### PR TITLE
Fix: accessible title in cloud snippet search results

### DIFF
--- a/src/css/manage/_cloud-community.scss
+++ b/src/css/manage/_cloud-community.scss
@@ -81,6 +81,25 @@
 
 	.cloud-snippet {
 		padding: 24px;
+
+		h3 .cloud-snippet-title-button {
+			display: inline;
+			margin: 0;
+			padding: 0;
+			border: none;
+			background: none;
+			font: inherit;
+			color: #2271b1;
+			cursor: pointer;
+			text-align: start;
+			text-decoration: underline;
+		}
+
+		h3 .cloud-snippet-title-button:focus-visible {
+			outline: 2px solid #2271b1;
+			outline-offset: 2px;
+			border-radius: 2px;
+		}
 	}
 
 	.cloud-snippet-meta {

--- a/src/css/manage/_cloud-community.scss
+++ b/src/css/manage/_cloud-community.scss
@@ -82,7 +82,7 @@
 	.cloud-snippet {
 		padding: 24px;
 
-		h3 .cloud-snippet-title-button {
+		.cloud-snippet-title-button {
 			display: inline;
 			margin: 0;
 			padding: 0;
@@ -93,12 +93,12 @@
 			cursor: pointer;
 			text-align: start;
 			text-decoration: underline;
-		}
 
-		h3 .cloud-snippet-title-button:focus-visible {
-			outline: 2px solid #2271b1;
-			outline-offset: 2px;
-			border-radius: 2px;
+			&:focus-visible {
+				outline: 2px solid #2271b1;
+				outline-offset: 2px;
+				border-radius: 2px;
+			}
 		}
 	}
 

--- a/src/js/components/ManageMenu/CommunityCloud/SearchResults.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/SearchResults.tsx
@@ -30,16 +30,16 @@ interface CloudSnippetDetailsProps {
 const CloudSnippetDetails: React.FC<CloudSnippetDetailsProps> = ({ snippet, setIsPreviewOpen }) =>
 	<div className="cloud-snippet">
 		<h3>
-			<a
-				href="#"
+			<button
+				type="button"
+				className="cloud-snippet-title-button"
 				title={__('Preview this snippet', 'code-snippets')}
-				onClick={event => {
-					event.preventDefault()
+				onClick={() => {
 					setIsPreviewOpen(true)
 				}}
 			>
 				{snippet.name}
-			</a>
+			</button>
 		</h3>
 
 		<div className="cloud-snippet-meta">


### PR DESCRIPTION
Replace `<a href="#">` with `<button>` to improve semantics. Links are used only for linking to other pages. In this case, clicking the title open a modal. So, it's not a link.

The change also makes keyboard navigation more intuitive. Before you could open only with ENTER, after the change you can use either ENTER or SPACE.

**Before:**

<img width="797" height="843" alt="before" src="https://github.com/user-attachments/assets/d37fdc61-56c8-40a7-8c1f-69dbe12db050" />

**After:**

<img width="908" height="868" alt="after" src="https://github.com/user-attachments/assets/b9269323-6688-4ef2-afdb-b4af1c9ec0dd" />
