### PR TITLE
Fix: accessible import snippets tabs

### DIFF
--- a/src/js/components/ImportMenu/ImportMenu.tsx
+++ b/src/js/components/ImportMenu/ImportMenu.tsx
@@ -39,18 +39,17 @@ export const ImportMenu: React.FC = () => {
 			<div className="narrow">
 				<h2 className="nav-tab-wrapper">
 					{TABS.map(tab =>
-						<a
+						<button
 							key={tab}
-							href="#"
+							type="button"
 							className={classnames('nav-tab', { 'nav-tab-active': tab === activeTab })}
-							onClick={event => {
-								event.preventDefault()
+							onClick={() => {
 								setActiveTab(tab)
 								updateQueryParam('tab', tab)
 							}}
 						>
 							{TAB_LABELS[tab]}
-						</a>)}
+						</button>)}
 				</h2>
 
 				<WithRestAPIContext>


### PR DESCRIPTION
Replace `<a href="#">` with `<button>` to improve semantics. Links are used only for linking to other pages. In this case, clicking the element changes the tab. So, it's not a link.

<img width="656" height="459" alt="Screenshot 2026-04-10 at 14 03 34" src="https://github.com/user-attachments/assets/969cdf60-f394-4147-b820-cfd102fc92e1" />

