### PR TITLE
Fix: accessible code snippets toolbar

### DIFF
--- a/src/js/components/common/Toolbar.tsx
+++ b/src/js/components/common/Toolbar.tsx
@@ -84,7 +84,7 @@ const UpperNav: React.FC<NavProps> = ({ setIsUpsellDialogOpen }) =>
 			<h1>{__('Code Snippets', 'code-snippets')}</h1>
 		</div>
 
-		<nav aria-label={__('Navigation links', 'code-snippets')}>
+		<nav aria-label={__('Main links', 'code-snippets')}>
 			<ul>
 				{UPPER_NAV_LINKS.map(({ name, url, label, external }) =>
 					<li key={name}>
@@ -120,7 +120,7 @@ const currentPage = fetchQueryParam('subpage') ?? fetchQueryParam('page')
 
 const LowerNav: React.FC<NavProps> = ({ setIsUpsellDialogOpen }) =>
 	<div className="code-snippets-toolbar-lower">
-		<nav aria-label={__('Code snippets navigation', 'code-snippets')}>
+		<nav aria-label={__('Main features', 'code-snippets')}>
 			<ul>
 				{LOWER_NAV_LINKS.map(({ name, url, label, pro, icon }) =>
 					<li key={name}>

--- a/src/js/components/common/Toolbar.tsx
+++ b/src/js/components/common/Toolbar.tsx
@@ -78,12 +78,13 @@ const UpperNav: React.FC<NavProps> = ({ setIsUpsellDialogOpen }) =>
 			<img
 				src={`${window.CODE_SNIPPETS?.urls.plugin}/assets/icon.svg`}
 				alt={__('Code Snippets logo', 'code-snippets')}
+				aria-hidden="true"
 			/>
 
 			<h1>{__('Code Snippets', 'code-snippets')}</h1>
 		</div>
 
-		<nav>
+		<nav aria-label={__('Navigation links', 'code-snippets')}>
 			<ul>
 				{UPPER_NAV_LINKS.map(({ name, url, label, external }) =>
 					<li key={name}>
@@ -119,25 +120,27 @@ const currentPage = fetchQueryParam('subpage') ?? fetchQueryParam('page')
 
 const LowerNav: React.FC<NavProps> = ({ setIsUpsellDialogOpen }) =>
 	<div className="code-snippets-toolbar-lower">
-		<ul>
-			{LOWER_NAV_LINKS.map(({ name, url, label, pro, icon }) =>
-				<li key={name}>
-					<a
-						href={url ?? buildUrl(window.CODE_SNIPPETS?.urls.manage, { subpage: name })}
-						className={classnames(`${name}-link`, { 'active-link': currentPage?.endsWith(name) })}
-						onClick={event => {
-							if (pro && !isLicensed()) {
-								event.preventDefault()
-								setIsUpsellDialogOpen(true)
-							}
-						}}
-					>
-						{icon}
-						<span>{label}</span>
-						{pro && !isLicensed() && <span className="pro-chip">{__('Pro', 'code-snippets')}</span>}
-					</a>
-				</li>)}
-		</ul>
+		<nav aria-label={__('Code snippets navigation', 'code-snippets')}>
+			<ul>
+				{LOWER_NAV_LINKS.map(({ name, url, label, pro, icon }) =>
+					<li key={name}>
+						<a
+							href={url ?? buildUrl(window.CODE_SNIPPETS?.urls.manage, { subpage: name })}
+							className={classnames(`${name}-link`, { 'active-link': currentPage?.endsWith(name) })}
+							onClick={event => {
+								if (pro && !isLicensed()) {
+									event.preventDefault()
+									setIsUpsellDialogOpen(true)
+								}
+							}}
+						>
+							{icon}
+							<span>{label}</span>
+							{pro && !isLicensed() && <span className="pro-chip">{__('Pro', 'code-snippets')}</span>}
+						</a>
+					</li>)}
+			</ul>
+		</nav>
 	</div>
 
 export const Toolbar = () => {


### PR DESCRIPTION
This PR improves the toolbar accessibility. It hides the logo, adds missing `<nav>` element, and adds missing `aria-label` attributes to both `<nav>` elements explaining what type of navigation is that.


**The toolbar:**

<img width="1562" height="165" alt="image" src="https://github.com/user-attachments/assets/0ab11e6b-d0ca-4b98-a1ca-64e63fff2bf7" />


**Accessibility tree before:**

<img width="797" height="202" alt="image" src="https://github.com/user-attachments/assets/34a224b6-d7b3-4adc-83dc-99965d844321" />


**Accessibility tree after:**

<img width="712" height="143" alt="image" src="https://github.com/user-attachments/assets/0d6e192e-3ff9-416d-aa03-857a00556e36" />


**Note:**

The screenshots are outdated, the `aria-label` attributes changed to "Main links" and "Main features".