### PR TITLE
Fix: add semantics to snippets search box

### DIFF
--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -204,17 +204,19 @@ const SearchBox = () => {
 	const { searchQuery, setSearchQuery } = useSnippetsFilters()
 
 	return (
-		<p className="search-box">
-			<label className="screen-reader-text" htmlFor="snippets_search">{__('Search Snippets:', 'code-snippets')}</label>
-			<input
-				type="search"
-				id="snippets_search"
-				name="s"
-				value={searchQuery ?? ''}
-				onChange={event => setSearchQuery(event.target.value)}
-				placeholder={__('Search snippets', 'code-snippets')}
-			/>
-		</p>
+		<search aria-label={__('Search Snippets', 'code-snippets')}>
+			<p className="search-box">
+				<label className="screen-reader-text" htmlFor="snippets_search">{__('Search Snippets:', 'code-snippets')}</label>
+				<input
+					type="search"
+					id="snippets_search"
+					name="s"
+					value={searchQuery ?? ''}
+					onChange={event => setSearchQuery(event.target.value)}
+					placeholder={__('Search snippets', 'code-snippets')}
+				/>
+			</p>
+		</search>
 	)
 }
 


### PR DESCRIPTION
In the accessibility tree the search box is wrapped in a `<p>` element (inherited from WordPress, we can't change that).

To improve semantics, we can add a wrapping `<search>` element ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/search)).


Before:

<img width="1535" height="255" alt="search-before" src="https://github.com/user-attachments/assets/71c229f2-f81b-4d70-90bf-a5f8e262f718" />


After:

<img width="1522" height="262" alt="search-after" src="https://github.com/user-attachments/assets/a72702ee-ccaa-42fe-ba9c-cf7a1f850ea5" />
