### PR TITLE
Fix: improve code-mirror accessibility (tab trap)

### DIFF
--- a/src/js/components/EditMenu/SnippetForm/SnippetForm.tsx
+++ b/src/js/components/EditMenu/SnippetForm/SnippetForm.tsx
@@ -152,7 +152,7 @@ const EditFormWrap: React.FC = () => {
 			<Notices placement="above-form" />
 
 			<EditForm className={editFormClassName({ snippet, isReadOnly, isExpanded })}>
-				<main className="snippet-form-upper">
+				<div className="snippet-form-upper">
 					<div className="snippet-name-wrapper">
 						<NameInput />
 						<SnippetTypeInput setIsUpgradeDialogOpen={setIsUpgradeDialogOpen} />
@@ -160,7 +160,7 @@ const EditFormWrap: React.FC = () => {
 
 					<CodeEditor {...{ isExpanded, setIsExpanded }} />
 					<ConditionsEditor />
-				</main>
+				</div>
 
 				<div className="snippet-form-lower">
 					<UpsellBanner />

--- a/src/js/components/EditMenu/SnippetForm/fields/CodeEditor.tsx
+++ b/src/js/components/EditMenu/SnippetForm/fields/CodeEditor.tsx
@@ -41,7 +41,12 @@ const EditorTextarea: React.FC<EditorTextareaProps> = ({ textareaRef }) => {
 	const { snippet, setSnippet } = useSnippetForm()
 
 	return (
-		<div className="snippet-editor">
+		<div
+			className="snippet-editor"
+			role="application"
+			aria-label={__('Code editor', 'code-snippets')}
+			aria-description={__('In the editing area, the Tab key enters a tab character. To exit the code editor, press the Escape key and then the Tab key.', 'code-snippets')}
+		>
 			<textarea
 				ref={textareaRef}
 				id="snippet-code"


### PR DESCRIPTION
Code mirror has a tab trap issue (not really.

This PR solves it by adding usage instruction - `Tab` to add tab character, and `Escape`+`Tab` to exit the code editor.

<img width="1419" height="506" alt="image" src="https://github.com/user-attachments/assets/85130340-ea10-4d2a-9050-3c0adf2c2757" />

See related issue in WordPress core - https://core.trac.wordpress.org/changeset/41586