### PR TITLE
Fix: accessible "Run Once" link to run the code

### DIFF
--- a/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
@@ -39,6 +39,7 @@ const ActivateColumn: React.FC<ColumnProps> = ({ snippet }) => {
 				<a
 					className="snippet-execution-button"
 					title={__('Run Once', 'code-snippets')}
+					aria-label={__('Run Once', 'code-snippets')}
 					href={buildUrl(window.location.href, { action: 'run-once', snippet: snippet.id })}
 				>
 					&nbsp;


### PR DESCRIPTION
The "Run once" link has visible content of essentially ` ` with only a `title` attribute. `title` is a weak, non-universal accessible name. If we add `aria-label` we can improve accessibility for this element, adding an accessible name to the link.

Before:

<img width="1542" height="607" alt="before" src="https://github.com/user-attachments/assets/ae353c38-5b46-464f-be53-8779c15ab71d" />

After:

<img width="1538" height="611" alt="after" src="https://github.com/user-attachments/assets/a97a51c4-8d9f-49aa-b42d-9417f539929b" />
