### PR TITLE
Fix: hide empty cloud snippet description paragraph

### DIFF
--- a/src/js/components/ManageMenu/CommunityCloud/SearchResults.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/SearchResults.tsx
@@ -56,11 +56,13 @@ const CloudSnippetDetails: React.FC<CloudSnippetDetailsProps> = ({ snippet, setI
 				: null}
 		</div>
 
-		<p className="cloud-snippet-description">
-			{snippet.description.length > MAX_DESCRIPTION_LENGTH
-				? `${snippet.description.slice(0, MAX_DESCRIPTION_LENGTH)}…`
-				: snippet.description}
-		</p>
+		{snippet.description && (
+			<p className="cloud-snippet-description">
+				{snippet.description.length > MAX_DESCRIPTION_LENGTH
+					? `${snippet.description.slice(0, MAX_DESCRIPTION_LENGTH)}…`
+					: snippet.description}
+			</p>
+		)}
 
 		<p className="cloud-snippet-author">
 			{_x('by ', 'snippet author', 'code-snippets')}


### PR DESCRIPTION
If the cloud snippet doesn't have a description, don't print an empty paragraph.

<img width="1751" height="657" alt="image" src="https://github.com/user-attachments/assets/7886b8e7-6d81-4030-9a64-e2f0a8a7b2a0" />
