### PR TITLE
Fix: update "what's new" page markup & headings structure

### DIFF
--- a/src/css/welcome.scss
+++ b/src/css/welcome.scss
@@ -8,7 +8,7 @@ $breakpoint: 1060px;
 .code-snippets-welcome {
 	padding: 25px;
 
-	h1 {
+	h2 {
 		font-size: 32px;
 		margin-block: 48px 32px;
 	}
@@ -25,7 +25,7 @@ $breakpoint: 1060px;
 		padding: 32px;
 	}
 
-	header {
+	.code-snippets-header-wrapper {
 		display: flex;
 		flex-flow: row;
 		justify-content: space-between;
@@ -35,7 +35,7 @@ $breakpoint: 1060px;
 		padding-block-end: 20px;
 	}
 
-	h2 {
+	h3 {
 		font-size: 18px;
 		margin: 0;
 	}
@@ -68,8 +68,9 @@ $breakpoint: 1060px;
 .code-snippets-partners,
 .code-snippets-articles {
 	display: flex;
-	flex-direction: row;;
+	flex-direction: row;
 	gap: 16px;
+	margin: 0;
 
 	figure {
 		margin: 0;
@@ -89,6 +90,7 @@ $breakpoint: 1060px;
 	background: #fff;
 	border-radius: 8px;
 	display: flex;
+	margin: 0;
 	flex-flow: column;
 	color: #2c3337;
 
@@ -99,7 +101,7 @@ $breakpoint: 1060px;
 }
 
 .code-snippets-partners {
-	header {
+	.code-snippets-header-wrapper {
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
@@ -109,7 +111,7 @@ $breakpoint: 1060px;
 }
 
 .code-snippets-articles {
-	header {
+	.code-snippets-header-wrapper {
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
@@ -122,7 +124,7 @@ $breakpoint: 1060px;
 		margin-block-start: auto;
 	}
 
-	h2 {
+	h3 {
 		font-size: 18px;
 		margin: 0;
 	}
@@ -154,21 +156,27 @@ $breakpoint: 1060px;
 	color: #2c3337;
 	padding-inline-end: 1em;
 
-	header {
-		border: 0;
-		margin: 0;
-		padding: 0;
+	h3 {
+		font-size: 16px;
+		display: flex;
 
-		p {
+		&:not(:first-of-type) {
+			margin-block-start: 100px;
+		}
+
+		span {
 			font-size: 14px;
+			font-weight: normal;
+			margin-inline-start: auto;
 		}
 	}
 
-	h3 {
-		font-size: 16px;
+	h4 {
+		font-size: 14px;
+		margin: 1em 0;
 	}
 
-	h4 {
+	h5 {
 		font-size: 12px;
 		text-transform: uppercase;
 		margin: 0 0 16px;
@@ -187,23 +195,6 @@ $breakpoint: 1060px;
 		grid-template-rows: 1fr;
 		align-items: baseline;
 		gap: 10px;
-	}
-
-	> article::after {
-		border-block-end: 1px solid #666;
-		content: ' ';
-		display: block;
-		inline-size: 50%;
-		margin-block: 3em;
-		margin-inline: auto;
-	}
-
-	> article:last-child {
-		padding-block-end: 1px;
-
-		&::after {
-			border: 0;
-		}
 	}
 
 	$icon-colors: (

--- a/src/js/components/WelcomeMenu/Changelog.tsx
+++ b/src/js/components/WelcomeMenu/Changelog.tsx
@@ -56,8 +56,8 @@ const ChangelogSection: React.FC<ChangelogSectionProps> = ({ section, entries })
 
 export const Changelog = () =>
 	<div className="code-snippets-changelog">
-		<header>
-			<h2>{__('Latest changes', 'code-snippets')}</h2>
+		<div className="code-snippets-header-wrapper">
+			<h3>{__('Latest changes', 'code-snippets')}</h3>
 			<a
 				href="https://wordpress.org/plugins/code-snippets/changelog"
 				className="button button-primary button-large"
@@ -65,21 +65,22 @@ export const Changelog = () =>
 			>
 				{__('View changelog', 'code-snippets')}
 			</a>
-		</header>
+		</div>
 		<div className="code-snippets-changelog-entries">
 			{CHANGELOG_DATA?.map(({ version, date, entries }) =>
 				<Fragment key={version}>
-					<header>
-						{/* translators: %s: version number. */}
-						<h3>{sprintf(__('Version %s', 'code-snippets'), version)}</h3>
-						<p>{date}</p>
-					</header>
-					<article>
-						{CHANGELOG_SECTIONS.map(section =>
-							entries[section]
-								? <ChangelogSection key={section} section={section} entries={entries[section]} />
-								: null)}
-					</article>
+					<h3>
+						{sprintf(
+							/* translators: %s: version number. */
+							__('Version %s', 'code-snippets'),
+							version
+						)}
+						<span>{date}</span>
+					</h3>
+					{CHANGELOG_SECTIONS.map(section =>
+						entries[section]
+							? <ChangelogSection key={section} section={section} entries={entries[section]} />
+							: null)}
 				</Fragment>)}
 		</div>
 	</div>

--- a/src/js/components/WelcomeMenu/WelcomeMenu.tsx
+++ b/src/js/components/WelcomeMenu/WelcomeMenu.tsx
@@ -11,8 +11,8 @@ const HeroImage = () => {
 
 	return (
 		<div className="code-snippets-hero">
-			<header>
-				<h2>{DATA?.hero.name}</h2>
+			<div className="code-snippets-header-wrapper">
+				<h3>{DATA?.hero.name}</h3>
 				<a
 					className="button button-primary button-large"
 					href={DATA?.hero.follow_url}
@@ -21,7 +21,7 @@ const HeroImage = () => {
 				>
 					{__('Read more', 'code-snippets')}
 				</a>
-			</header>
+			</div>
 			<figure>
 				{!isImageLoaded && <div className="code-snippets-loading-spinner"></div>}
 				<img
@@ -40,21 +40,21 @@ interface PartnersProps {
 
 const Partners: React.FC<PartnersProps> = ({ partners }) =>
 	<>
-		<h1>{__('Exclusive deals from our partners', 'code-snippets')}</h1>
-		<section className="code-snippets-partners">
+		<h2>{__('Exclusive deals from our partners', 'code-snippets')}</h2>
+		<ul className="code-snippets-partners">
 			{partners.map(({ title, follow_url, image_url }) =>
-				<article key={title} className="code-snippets-card">
+				<li key={title} className="code-snippets-card">
 					<figure>
 						<img src={image_url} alt={__('Partner image', 'code-snippets')} />
 					</figure>
-					<header>
+					<div className="code-snippets-header-wrapper">
 						<h3>{title}</h3>
 						<a href={follow_url} target="_blank" rel="noopener noreferrer">
 							{__('Visit', 'code-snippets')}
 						</a>
-					</header>
-				</article>)}
-		</section>
+					</div>
+				</li>)}
+		</ul>
 	</>
 
 interface ArticlesProps {
@@ -63,30 +63,30 @@ interface ArticlesProps {
 
 const Articles: React.FC<ArticlesProps> = ({ articles }) =>
 	<>
-		<h1>{__('Helpful articles', 'code-snippets')}</h1>
-		<section className="code-snippets-articles">
+		<h2>{__('Helpful articles', 'code-snippets')}</h2>
+		<ul className="code-snippets-articles">
 			{articles.map(({ title, follow_url, image_url, description, category }) =>
-				<article key={title} className="code-snippets-card">
+				<li key={title} className="code-snippets-card">
 					<figure>
 						<img src={image_url} alt={__('Feature image', 'code-snippets')} />
 					</figure>
-					<header>
+					<div className="code-snippets-header-wrapper">
 						<p className="item-category">{category}</p>
-						<h2>{title}</h2>
+						<h3>{title}</h3>
 						<p className="item-description">{description}</p>
 						<a href={follow_url} className="button button-secondary" target="_blank" rel="noopener noreferrer">
 							{__('Read more', 'code-snippets')}
 						</a>
-					</header>
-				</article>)}
-		</section>
+					</div>
+				</li>)}
+		</ul>
 	</>
 
 export const WelcomeMenu = () =>
 	<>
 		<Toolbar />
 		<div className="code-snippets-welcome">
-			<h1>{__('Resources and Updates', 'code-snippets')}</h1>
+			<h2>{__('Resources and Updates', 'code-snippets')}</h2>
 
 			<div className="code-snippets-updates">
 				<HeroImage />

--- a/src/js/components/WelcomeMenu/WelcomeMenu.tsx
+++ b/src/js/components/WelcomeMenu/WelcomeMenu.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n'
+import { __, sprintf } from '@wordpress/i18n'
 import React, { useState } from 'react'
 import { Toolbar } from '../common/Toolbar'
 import { Changelog } from './Changelog'
@@ -49,7 +49,7 @@ const Partners: React.FC<PartnersProps> = ({ partners }) =>
 					</figure>
 					<div className="code-snippets-header-wrapper">
 						<h3>{title}</h3>
-						<a href={follow_url} target="_blank" rel="noopener noreferrer">
+						<a href={follow_url} target="_blank" rel="noopener noreferrer" aria-label={sprintf( /* translators: %s: partner name. */ __('Visit %s', 'code-snippets'), title)}>
 							{__('Visit', 'code-snippets')}
 						</a>
 					</div>


### PR DESCRIPTION
Tweak markup and fix headings structure

<img width="1895" height="944" alt="image" src="https://github.com/user-attachments/assets/138a84ac-dcb3-40e8-83cf-4090fdcc5ae2" />
