### PR TITLE
Fix: remove Enter key handling from ConfirmDialog component

### DIFF
--- a/src/js/components/common/ConfirmDialog.tsx
+++ b/src/js/components/common/ConfirmDialog.tsx
@@ -30,11 +30,6 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
 			onRequestClose={onCancel}
 			closeButtonLabel={cancelLabel}
 			isDismissible={true}
-			onKeyDown={event => {
-				if ('Enter' === event.key) {
-					onConfirm?.()
-				}
-			}}
 		>
 			{children}
 			<Flex direction="row" justify="flex-end">


### PR DESCRIPTION
The `ConfirmDialog.tsx` captures `onKeyDown` to trigger dialog confirmation.

The issue is that `onKeyDown` captures Enter globally within the modal.

This can conflict with screen reader virtual buffer navigation and activate the confirm action unintentionally.

To avoid unintentional activation, the dialog should capture Enter key only when focus is on the confirm button, or use native button activation behavior.