### PR TITLE
Fix: improve tooltips accessibility

### DIFF
--- a/src/css/common/_tooltips.scss
+++ b/src/css/common/_tooltips.scss
@@ -36,6 +36,24 @@ $bg-color: hsl(0deg 0% 20% / 90%);
 	}
 }
 
+.tooltip-trigger {
+	cursor: help;
+	display: inline-flex;
+	align-items: center;
+	background: transparent;
+	padding: 0;
+	margin: 0;
+	border: 0;
+	border-radius: 50%;
+	color: inherit;
+	font: inherit;
+
+	&:hover,
+	&:focus {
+		box-shadow: none;
+	}
+}
+
 .tooltip::before,
 .tooltip-content {
 	position: absolute;
@@ -148,7 +166,8 @@ $bg-color: hsl(0deg 0% 20% / 90%);
 }
 
 .tooltip:hover,
-.tooltip:focus {
+.tooltip:focus,
+.tooltip:focus-within {
 	&::before, .tooltip-content {
 		visibility: visible;
 		opacity: 1;
@@ -156,28 +175,32 @@ $bg-color: hsl(0deg 0% 20% / 90%);
 }
 
 .tooltip-block.tooltip-start:hover,
-.tooltip-block.tooltip-start:focus {
+.tooltip-block.tooltip-start:focus,
+.tooltip-block.tooltip-start:focus-within {
 	&::before, .tooltip-content {
 		transform: translateY(-10px);
 	}
 }
 
 .tooltip-block.tooltip-end:hover,
-.tooltip-block.tooltip-end:focus {
+.tooltip-block.tooltip-end:focus,
+.tooltip-block.tooltip-end:focus-within {
 	&::before, .tooltip-content {
 		transform: translateY(10px);
 	}
 }
 
 .tooltip-inline.tooltip-end:hover,
-.tooltip-inline.tooltip-end:focus {
+.tooltip-inline.tooltip-end:focus,
+.tooltip-inline.tooltip-end:focus-within {
 	&::before, .tooltip-content {
 		transform: translateX(calc(10px * var(--cs-direction-multiplier)));
 	}
 }
 
 .tooltip-inline.tooltip-start:hover,
-.tooltip-inline.tooltip-start:focus {
+.tooltip-inline.tooltip-start:focus,
+.tooltip-inline.tooltip-start:focus-within {
 	&::before, .tooltip-content {
 		transform: translateX(calc(-10px * var(--cs-direction-multiplier)));
 	}

--- a/src/js/components/common/Tooltip.tsx
+++ b/src/js/components/common/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useId } from 'react'
 import classnames from 'classnames'
 import { __ } from '@wordpress/i18n'
 import { trimTrailingChar } from '../../utils/text'
@@ -12,21 +12,38 @@ export interface TooltipProps {
 	icon?: ReactNode
 	children: ReactNode
 	className?: classnames.Argument
+	label?: string
 }
 
-export const Tooltip: React.FC<TooltipProps> = ({ block, inline, start, end, icon, className, children }) =>
-	<div className={classnames(
-		'tooltip',
-		{ 'tooltip-block': block, 'tooltip-inline': inline, 'tooltip-start': start, 'tooltip-end': end },
-		className
-	)}>
-		{icon ?? <span className="dashicons dashicons-editor-help" aria-hidden="true"></span>}
-		<div className="tooltip-content">
-			{children}
+export const Tooltip: React.FC<TooltipProps> = ({ block, inline, start, end, icon, className, children, label }) => {
+	const tooltipId = useId()
+	return (
+		<div className={classnames(
+			'tooltip',
+			{ 'tooltip-block': block, 'tooltip-inline': inline, 'tooltip-start': start, 'tooltip-end': end },
+			className
+		)}>
+			<button
+				type="button"
+				className="tooltip-trigger"
+				aria-label={label ?? __('More information', 'code-snippets')}
+				aria-describedby={tooltipId}
+			>
+				{icon ?? <span className="dashicons dashicons-editor-help" aria-hidden="true"></span>}
+			</button>
+			<div role="tooltip" className="tooltip-content" id={tooltipId}>
+				{children}
+			</div>
 		</div>
-	</div>
+	)
+}
 
 export const ErrorTooltip: React.FC<{ message: string }> = ({ message }) =>
-	<Tooltip block end icon={<span className="dashicons dashicons-warning" aria-hidden="true"></span>}>
+	<Tooltip
+		block
+		end
+		label={__('Error', 'code-snippets')}
+		icon={<span className="dashicons dashicons-warning" aria-hidden="true"></span>}
+	>
 		{`${trimTrailingChar(message, '.!?')}. ${__('Please try again.', 'code-snippets')}`}
 	</Tooltip>


### PR DESCRIPTION
Currently, screen readers never announce tooltip text because it's a purely visual (CSS).

When you hover over the tooltip, it displays it. But it's not reachable for keyboard users.

With this PR, the tooltip can now be reached using your keyboard.

<img width="420" height="244" alt="image" src="https://github.com/user-attachments/assets/13c65f66-fedd-4bba-99d9-2062daa34ec1" />

In addition, the accessibility tree is more clear:

<img width="909" height="390" alt="image" src="https://github.com/user-attachments/assets/355fa162-2555-4c63-8c11-a3965c5462e5" />
