### PR TITLE
Fix: accessible color contrast

### DIFF
--- a/src/css/common/_switch.scss
+++ b/src/css/common/_switch.scss
@@ -50,7 +50,7 @@ input[type='checkbox'].switch:checked {
 	text-align: center;
 	font-weight: bold;
 	line-height: 1;
-	color: #bbb;
+	color: #1d2327;
 }
 
 a.snippet-condition-count {

--- a/src/css/common/_upsell.scss
+++ b/src/css/common/_upsell.scss
@@ -34,7 +34,7 @@
 		text-decoration: none;
 		font-weight: normal;
 		padding: 0;
-		color: #a7aaad;
+		color: #646970;
 		line-height: 1;
 	}
 }

--- a/src/css/manage/_snippets-table.scss
+++ b/src/css/manage/_snippets-table.scss
@@ -91,7 +91,7 @@
 	}
 
 	.row-actions {
-		color: #ddd;
+		color: #646970;
 		position: relative;
 		inset-inline-start: 0;
 

--- a/src/css/settings.scss
+++ b/src/css/settings.scss
@@ -74,7 +74,7 @@ body.js {
 	display: inline-block;
 	padding-inline-end: 2em;
 	line-height: 2;
-	color: #aaa;
+	color: #646970;
 }
 
 .license-status-valid {
@@ -121,8 +121,8 @@ body.js {
 }
 
 .refresh-success {
-	background: #2271b1;
-	color: #ffeb3b;
+	background: #2e7d4f;
+	color: #fff;
 }
 
 .cloud-settings tbody tr:nth-child(n+5) {


### PR DESCRIPTION
Several text colors are potentially below the 4.5:1 contrast ratio for normal text - WCAG 1.4.3 requires 4.5:1 for normal text.