### PR TITLE
Fix: consistent heading structure across all admin screens

### DIFF
--- a/src/css/common/_upsell.scss
+++ b/src/css/common/_upsell.scss
@@ -76,19 +76,11 @@
 	p {
 		margin-block: 0;
 		margin-inline: 2em;
-	}
-
-	h1 + p {
 		font-size: 16px;
 	}
 
 	img {
 		inline-size: 82px;
-	}
-
-	h2 {
-		text-transform: uppercase;
-		font-size: 12px;
 	}
 
 	ul {

--- a/src/css/edit.scss
+++ b/src/css/edit.scss
@@ -89,6 +89,14 @@
 	}
 }
 
+.wrap > h2:first-of-type {
+	font-size: 1.5rem;
+	font-weight: 400;
+	line-height: 1.3;
+	padding: 0;
+	margin-block: 50px 1rem;
+}
+
 .snippet-name-wrapper {
 	display: flex;
 	gap: 0.5em;

--- a/src/css/manage.scss
+++ b/src/css/manage.scss
@@ -39,20 +39,17 @@
 	align-items: center;
 	margin-block: 50px 1.4rem;
 
-	h1 {
-		font-size: 1.6rem;
-		padding: 0;
-	}
-
 	.button-primary {
 		margin-inline-start: auto;
 	}
 }
 
-.wrap > h1:first-of-type {
-	font-size: 1.6rem;
+.wrap > h2:first-of-type {
+	font-size: 1.5rem;
+	font-weight: 400;
+	line-height: 1.3;
 	padding: 0;
-	margin-block: 50px 1.4rem;
+	margin-block: 50px 1rem;
 
 	.subtitle {
 		vertical-align: middle;

--- a/src/css/manage.scss
+++ b/src/css/manage.scss
@@ -34,16 +34,6 @@
 	margin-inline: 0;
 }
 
-.snippets-table-heading {
-	display: flex;
-	align-items: center;
-	margin-block: 50px 1.4rem;
-
-	.button-primary {
-		margin-inline-start: auto;
-	}
-}
-
 .wrap > h2:first-of-type {
 	font-size: 1.5rem;
 	font-weight: 400;

--- a/src/css/settings.scss
+++ b/src/css/settings.scss
@@ -3,6 +3,14 @@
 
 $sections: general, editor, debug, version-switch;
 
+.wrap > h2:first-of-type {
+	font-size: 1.5rem;
+	font-weight: 400;
+	line-height: 1.3;
+	padding: 0;
+	margin-block: 50px 1rem;
+}
+
 p.submit {
 	display: flex;
 	justify-content: space-between;

--- a/src/css/welcome.scss
+++ b/src/css/welcome.scss
@@ -6,11 +6,12 @@
 $breakpoint: 1060px;
 
 .code-snippets-welcome {
-	padding: 25px;
-
 	h2 {
-		font-size: 32px;
-		margin-block: 48px 32px;
+		font-size: 1.5rem;
+		font-weight: 500;
+		line-height: 1.3;
+		padding: 0;
+		margin-block: 50px 1rem;
 	}
 }
 
@@ -174,15 +175,6 @@ $breakpoint: 1060px;
 	h4 {
 		font-size: 14px;
 		margin: 1em 0;
-	}
-
-	h5 {
-		font-size: 12px;
-		text-transform: uppercase;
-		margin: 0 0 16px;
-		display: flex;
-		gap: 5px;
-		align-items: center;
 	}
 
 	ul {

--- a/src/js/components/EditMenu/SnippetForm/page/PageHeading.tsx
+++ b/src/js/components/EditMenu/SnippetForm/page/PageHeading.tsx
@@ -27,7 +27,7 @@ export const PageHeading: React.FC = () => {
 	const { snippet, updateSnippet, setCurrentNotice } = useSnippetForm()
 
 	return (
-		<h1>
+		<h2>
 			{snippet.id
 				? <>
 					{`${getPageHeading(snippet)} `}
@@ -57,6 +57,6 @@ export const PageHeading: React.FC = () => {
 					<a key={label} href={url} className="page-title-action">{label}</a>{' '}
 				</>
 			)}
-		</h1>
+		</h2>
 	)
 }

--- a/src/js/components/ManageMenu/CommunityCloud/CommunityCloud.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/CommunityCloud.tsx
@@ -24,7 +24,7 @@ export const CommunityCloud = () => {
 
 	return (
 		<div className="wrap">
-			<h1>{__('Community Cloud', 'code-snippets')}</h1>
+			<h2>{__('Community Cloud', 'code-snippets')}</h2>
 
 			<nav
 				className="nav-tab-wrapper"

--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsTable.tsx
@@ -61,7 +61,7 @@ const PageHeading = () => {
 				{__('Create new snippet', 'code-snippets')}
 			</a>
 
-			<h1>
+			<h2>
 				{__('Manage Code Snippets', 'code-snippets')}
 
 				{searchQueryText || currentTag
@@ -86,7 +86,7 @@ const PageHeading = () => {
 						</Button>
 					</span>
 					: null}
-			</h1>
+			</h2>
 
 			<SafeModeNotice />
 		</>

--- a/src/js/components/common/UpsellDialog.tsx
+++ b/src/js/components/common/UpsellDialog.tsx
@@ -45,7 +45,7 @@ export const UpsellDialog: React.FC<UpsellDialogProps> = ({ isOpen, setIsOpen })
 				{__('Explore Code Snippets Pro', 'code-snippets')}
 			</a>
 
-			<h2>{__("Here's what else you get with Pro:", 'code-snippets')}</h2>
+			<p>{__("Here's what else you get with Pro:", 'code-snippets')}</p>
 			<ul>
 				<li>{__('Create, explain and verify snippets with AI', 'code-snippets')}</li>
 				<li>{__('Control when snippets run with Conditions', 'code-snippets')}</li>

--- a/src/php/Admin/Menus/Settings_Menu.php
+++ b/src/php/Admin/Menus/Settings_Menu.php
@@ -199,7 +199,7 @@ class Settings_Menu extends Admin_Menu {
 
 		?>
 		<div class="code-snippets-settings wrap" data-active-tab="<?php echo esc_attr( $current_section ); ?>">
-			<h1>
+			<h2>
 				<?php
 				esc_html_e( 'Settings', 'code-snippets' );
 
@@ -219,7 +219,7 @@ class Settings_Menu extends Admin_Menu {
 					}
 				}
 				?>
-			</h1>
+			</h2>
 
 			<?php settings_errors( OPTION_NAME ); ?>
 
@@ -275,7 +275,7 @@ class Settings_Menu extends Admin_Menu {
 
 			if ( $section['title'] ) {
 				printf(
-					'<h2 id="%s-settings" class="settings-section-title">%s</h2>' . "\n",
+					'<h3 id="%s-settings" class="settings-section-title">%s</h3>' . "\n",
 					esc_attr( $section['id'] ),
 					esc_html( $section['title'] )
 				);


### PR DESCRIPTION
The `<Toolbar>` has a `<h1>` tag. The other `<h1>` tags should be downgraded, and the sizes should be consistent across all the admin screens.

<img width="1267" height="992" alt="two-h1-tags" src="https://github.com/user-attachments/assets/403ada9e-71f0-4afc-9941-8e39eff9f541" />
