### PR TITLE
Fix: accessible snippets pagination

### DIFF
--- a/src/js/components/common/ListTable/TablePagination.tsx
+++ b/src/js/components/common/ListTable/TablePagination.tsx
@@ -178,6 +178,44 @@ interface PaginationControlsProps {
 	setCurrentPage: (page: number) => void
 }
 
+type NavigationLinksProps = Omit<PaginationControlsProps, 'totalItems'>
+
+const NavigationLinks: React.FC<NavigationLinksProps> = ({
+	which,
+	disabled,
+	totalPages,
+	inputValue,
+	currentPage,
+	useQueryVars,
+	setCurrentPage,
+	setInputValue
+}) => (
+	<span className="pagination-links">
+		<BackwardNavigationButtons
+			disabled={disabled}
+			currentPage={currentPage}
+			renderAsLinks={useQueryVars}
+			setCurrentPage={setCurrentPage}
+		/>
+		<CurrentPage
+			which={which}
+			disabled={disabled}
+			totalPages={totalPages}
+			currentPage={currentPage}
+			inputValue={inputValue}
+			setInputValue={setInputValue}
+			confirmInputValue={() => setCurrentPage(inputValue)}
+		/>{'\n'}
+		<ForwardNavigationButtons
+			disabled={disabled}
+			totalPages={totalPages}
+			currentPage={currentPage}
+			renderAsLinks={useQueryVars}
+			setCurrentPage={setCurrentPage}
+		/>
+	</span>
+)
+
 const PaginationControls: React.FC<PaginationControlsProps> = ({
 	which,
 	disabled,
@@ -188,49 +226,39 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
 	useQueryVars,
 	setCurrentPage,
 	setInputValue
-}) =>
-	<form
-		className={classnames('tablenav-pages', {
-			'one-page': totalPages && 1 === totalPages,
-			'no-pages': !totalPages
-		})}
-		onSubmit={event => {
-			event.preventDefault()
-			setCurrentPage(inputValue)
-		}}
-	>
-		<span className="displaying-num">
-			{/* translators: %s: Number of items. */}
-			{sprintf(_n('%s item', '%s items', totalItems), totalItems)}
-		</span>{'\n'}
+}) => {
+	const navLabel = 'top' === which
+		? __('Pagination, before the table', 'code-snippets')
+		: __('Pagination, after the table', 'code-snippets')
 
-		<span className="pagination-links">
-			<BackwardNavigationButtons
-				disabled={disabled}
-				currentPage={currentPage}
-				renderAsLinks={useQueryVars}
-				setCurrentPage={setCurrentPage}
-			/>
-
-			<CurrentPage
-				which={which}
-				disabled={disabled}
-				totalPages={totalPages}
-				currentPage={currentPage}
-				inputValue={inputValue}
-				setInputValue={setInputValue}
-				confirmInputValue={() => setCurrentPage(inputValue)}
-			/>{'\n'}
-
-			<ForwardNavigationButtons
-				disabled={disabled}
-				totalPages={totalPages}
-				currentPage={currentPage}
-				renderAsLinks={useQueryVars}
-				setCurrentPage={setCurrentPage}
-			/>
-		</span>
-	</form>
+	return (
+		<nav aria-label={navLabel}>
+			<form
+				className={classnames('tablenav-pages', {
+					'one-page': totalPages && 1 === totalPages,
+					'no-pages': !totalPages
+				})}
+				onSubmit={event => {
+					event.preventDefault()
+					setCurrentPage(inputValue)
+				}}
+			>
+				<span className="displaying-num">
+					{
+						sprintf(
+							// translators: %s: Number of items.
+							_n('%s item', '%s items', totalItems),
+							totalItems
+						)
+					}
+				</span>{'\n'}
+				<NavigationLinks
+					{...{ which, disabled, totalPages, inputValue, currentPage, useQueryVars, setCurrentPage, setInputValue }}
+				/>
+			</form>
+		</nav>
+	)
+}
 
 export interface TablePaginationProps extends Omit<ListTablePaginationProps, 'totalPages'>,
 	Required<Pick<ListTablePaginationProps, 'totalPages'>> {


### PR DESCRIPTION
<img width="495" height="334" alt="image" src="https://github.com/user-attachments/assets/8a2775c9-db21-45ae-8de9-3b9806b771cf" />

----

This pull request refactors the pagination controls in `TablePagination.tsx` to improve code organization and accessibility. The main changes include extracting navigation link logic into a separate `NavigationLinks` component and wrapping the pagination controls in a `<nav>` element with an accessible label.

Component refactoring and accessibility improvements:

* Extracted the navigation link buttons into a new `NavigationLinks` component, separating concerns and making the codebase more modular.
* Wrapped the pagination controls in a `<nav>` element with an `aria-label` to improve accessibility for screen readers. The label changes depending on whether the controls are above or below the table.
* Updated the main `PaginationControls` component to use the new `NavigationLinks` component and reorganized its structure for clarity.