### PR TITLE
Fix: accessible copy to clipboard button

### DIFF
--- a/src/js/components/common/CopyToClipboardButton.tsx
+++ b/src/js/components/common/CopyToClipboardButton.tsx
@@ -36,6 +36,13 @@ export interface CopyToClipboardButtonProps extends ButtonProps {
 	timeout?: number
 }
 
+const STATUS_MESSAGES: Record<Status, string> = {
+	[Status.INITIAL]: '',
+	[Status.PROGRESSING]: __('Copying to clipboard…', 'code-snippets'),
+	[Status.SUCCESS]: __('Copied to clipboard.', 'code-snippets'),
+	[Status.ERROR]: __('Failed to copy to clipboard. Please try again.', 'code-snippets')
+}
+
 export const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
 	text,
 	timeout = TIMEOUT,
@@ -55,17 +62,27 @@ export const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
 			.catch((error: unknown) => {
 				console.error('Failed to copy text to clipboard.', error)
 				setStatus(Status.ERROR)
+				setTimeout(() => setStatus(Status.INITIAL), timeout)
 			})
 	}
 
 	return clipboard && window.isSecureContext
-		? <Button
-			className="code-snippets-copy-text"
-			onClick={handleClick}
-			{...props}
-		>
-			<StatusIcon status={status} />
-			{__('Copy', 'code-snippets')}
-		</Button>
+		? <>
+			<Button
+				className="code-snippets-copy-text"
+				onClick={handleClick}
+				{...props}
+			>
+				<StatusIcon status={status} />
+				{__('Copy', 'code-snippets')}
+			</Button>
+			<span
+				className="screen-reader-text"
+				role={Status.ERROR === status ? 'alert' : 'status'}
+				aria-live={Status.ERROR === status ? 'assertive' : 'polite'}
+			>
+				{STATUS_MESSAGES[status]}
+			</span>
+		</>
 		: null
 }


### PR DESCRIPTION
This pull request improves the user experience and accessibility of the `CopyToClipboardButton` component by adding status messages and ensuring that screen readers can announce the result of copy actions.

**Accessibility and user feedback improvements:**

* Added a `STATUS_MESSAGES` record to map each copy status to a user-friendly, localized message, such as "Copied to clipboard." or "Failed to copy to clipboard. Please try again." (`src/js/components/common/CopyToClipboardButton.tsx`)
* Updated the button to display a visually hidden `<span>` with appropriate ARIA roles (`alert` or `status`) and `aria-live` attributes, allowing screen readers to announce the copy result. The message updates based on the current status. (`src/js/components/common/CopyToClipboardButton.tsx`)
* Ensured that error messages are reset to the initial state after a timeout when a copy error occurs, providing clear feedback for repeated attempts. (`src/js/components/common/CopyToClipboardButton.tsx`)