### PR TITLE
Fix: add PHPCS ignore for direct database query caching in REST API test

### DIFF
--- a/tests/phpunit/test-rest-api-snippets-shared-network-toggle.php
+++ b/tests/phpunit/test-rest-api-snippets-shared-network-toggle.php
@@ -167,7 +167,7 @@ class REST_API_Snippets_Shared_Network_Toggle_Test extends TestCase {
 		global $wpdb;
 
 		$table = code_snippets()->db->ms_table;
-		$value = $wpdb->get_var(
+		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare( "SELECT active FROM {$table} WHERE id = %d", $snippet_id )
 		);
 


### PR DESCRIPTION
<img width="835" height="108" alt="image" src="https://github.com/user-attachments/assets/5f8db17c-a252-4aa7-b845-6f708a6b2c01" />
