### PR TITLE
Fix: improve performance by loading Promotion only on WordPress admin

### DIFF
--- a/src/php/Plugin.php
+++ b/src/php/Plugin.php
@@ -137,7 +137,10 @@ class Plugin {
 		new MCE_Plugin();
 		new Upgrader( PLUGIN_VERSION, $this->db );
 		new Admin_Bar();
-		new Promotion_Manager();
+
+		if ( is_admin() ) {
+			new Promotion_Manager();
+		}
 
 		$this->init_snippet_files();
 	}


### PR DESCRIPTION
`Promotion_Manager` instantiates on every request (frontend included), but it should only be instantiated on WordPress admin.

`Promotion_Manager` constructs multiple notice objects. It already guards with `current_screen` in the base class, but the instantiation itself is unnecessary on frontend.
