### PR TITLE
Fix: improve performance by not loading REST controllers on frontend

### DIFF
--- a/src/php/Plugin.php
+++ b/src/php/Plugin.php
@@ -127,11 +127,17 @@ class Plugin {
 			$this->admin = new Bootstrap_Admin();
 		}
 
-		new Snippets_REST_Controller();
-		new Cloud_Snippets_REST_Controller( $this->cloud_api );
-		new Recently_Active_REST_Controller();
-		new Plugins_Import_REST_Controller();
-		new File_Import_REST_Controller();
+		add_action(
+			'rest_api_init',
+			function () {
+				new Snippets_REST_Controller();
+				new Cloud_Snippets_REST_Controller( $this->cloud_api );
+				new Recently_Active_REST_Controller();
+				new Plugins_Import_REST_Controller();
+				new File_Import_REST_Controller();
+			},
+			1
+		);
 
 		new Shortcodes();
 		new MCE_Plugin();


### PR DESCRIPTION
Code snippets registers 5 REST controllers on every request (frontend included).

Why it matters? Because it registers `rest_api_init` hooks on frontend requests where they will never fire (REST requests go through a separate path).

These five REST controller instances are created on every request, each adding an `add_action('rest_api_init', ...)` hook. On pure frontend page loads, `rest_api_init` never fires, so the routes are never registered — but the constructor + hook registration still runs.

The PR defers REST controller instantiation — wrap the 5 REST controllers in a single `rest_api_init` callback that creates them lazily. Saves ~5 object constructions + hook registrations on frontend.
