### PR TITLE
feat(new): insert code at the start of the body tag

### DIFF
--- a/src/js/components/EditMenu/SnippetForm/fields/SnippetLocationInput.tsx
+++ b/src/js/components/EditMenu/SnippetForm/fields/SnippetLocationInput.tsx
@@ -14,10 +14,12 @@ const SCOPE_ICONS: Record<SnippetCodeScope, string> = {
 	'single-use': 'clock',
 	'content': 'shortcode',
 	'head-content': 'editor-code',
+	'body-content': 'editor-code',
 	'footer-content': 'editor-code',
 	'admin-css': 'dashboard',
 	'site-css': 'admin-customizer',
 	'site-head-js': 'media-code',
+	'site-body-js': 'media-code',
 	'site-footer-js': 'media-code'
 }
 
@@ -27,12 +29,14 @@ const SCOPE_DESCRIPTIONS: Record<SnippetCodeScope, string> = {
 	'front-end': __('Only run on site front-end', 'code-snippets'),
 	'single-use': __('Only run once', 'code-snippets'),
 	'content': __('Where inserted in editor', 'code-snippets'),
-	'head-content': __('In site <head> section', 'code-snippets'),
+	'head-content': __('In site header (<head> section)', 'code-snippets'),
+	'body-content': __('In site content (start of <body>)', 'code-snippets'),
 	'footer-content': __('In site footer (end of <body>)', 'code-snippets'),
 	'site-css': __('Site front-end', 'code-snippets'),
 	'admin-css': __('Administration area', 'code-snippets'),
-	'site-footer-js': __('In site footer (end of <body>)', 'code-snippets'),
-	'site-head-js': __('In site <head> section', 'code-snippets')
+	'site-head-js': __('In site header (<head> section)', 'code-snippets'),
+	'site-body-js': __('In site content (start of <body>)', 'code-snippets'),
+	'site-footer-js': __('In site footer (end of <body>)', 'code-snippets')
 }
 
 export const SnippetLocationInput: React.FC = () => {

--- a/src/js/types/Snippet.ts
+++ b/src/js/types/Snippet.ts
@@ -28,8 +28,8 @@ export type SnippetScope = typeof SNIPPET_TYPE_SCOPES[SnippetType][number]
 
 export const SNIPPET_TYPE_SCOPES = <const> {
 	php: ['global', 'admin', 'front-end', 'single-use'],
-	html: ['content', 'head-content', 'footer-content'],
+	html: ['content', 'head-content', 'body-content', 'footer-content'],
 	css: ['admin-css', 'site-css'],
-	js: ['site-head-js', 'site-footer-js'],
+	js: ['site-head-js', 'site-body-js', 'site-footer-js'],
 	cond: ['condition']
 }

--- a/src/php/Integration/Evaluate_Content.php
+++ b/src/php/Integration/Evaluate_Content.php
@@ -43,6 +43,7 @@ class Evaluate_Content {
 	 */
 	public function init() {
 		add_action( 'wp_head', [ $this, 'load_head_content' ] );
+		add_action( 'wp_body_open', [ $this, 'load_body_content' ] );
 		add_action( 'wp_footer', [ $this, 'load_footer_content' ] );
 	}
 
@@ -63,7 +64,7 @@ class Evaluate_Content {
 				}
 			}
 		} else {
-			$scopes = [ 'head-content', 'footer-content' ];
+			$scopes = [ 'head-content', 'body-content', 'footer-content' ];
 
 			if ( is_null( $this->active_snippets ) ) {
 				$this->active_snippets = $this->db->fetch_active_snippets( $scopes );
@@ -88,6 +89,15 @@ class Evaluate_Content {
 	}
 
 	/**
+	 * Print body content snippets (requires theme to call wp_body_open).
+	 *
+	 * @return void
+	 */
+	public function load_body_content() {
+		$this->print_content_snippets( 'body-content' );
+	}
+
+	/**
 	 * Print footer content snippets.
 	 *
 	 * @return void
@@ -106,7 +116,7 @@ class Evaluate_Content {
 		$dir_name = $handler->get_dir_name();
 		$ext = $handler->get_file_extension();
 
-		$scopes = [ 'head-content', 'footer-content' ];
+		$scopes = [ 'head-content', 'body-content', 'footer-content' ];
 		$all_snippets = Snippet_Files::get_active_snippets_from_flat_files( $scopes, $dir_name );
 
 		foreach ( $all_snippets as $snippet ) {

--- a/src/php/Model/Snippet.php
+++ b/src/php/Model/Snippet.php
@@ -312,9 +312,9 @@ class Snippet extends Model {
 	public static function get_all_scopes(): array {
 		return array(
 			'global', 'admin', 'front-end', 'single-use',
-			'content', 'head-content', 'footer-content',
+			'content', 'head-content', 'body-content', 'footer-content',
 			'admin-css', 'site-css',
-			'site-head-js', 'site-footer-js',
+			'site-head-js', 'site-body-js', 'site-footer-js',
 			'condition',
 		);
 	}
@@ -332,10 +332,12 @@ class Snippet extends Model {
 			'single-use'     => 'clock',
 			'content'        => 'shortcode',
 			'head-content'   => 'editor-code',
+			'body-content'   => 'editor-code',
 			'footer-content' => 'editor-code',
 			'admin-css'      => 'dashboard',
 			'site-css'       => 'admin-customizer',
 			'site-head-js'   => 'media-code',
+			'site-body-js'   => 'media-code',
 			'site-footer-js' => 'media-code',
 			'condition'      => 'randomize',
 		);
@@ -361,6 +363,8 @@ class Snippet extends Model {
 				return __( 'Content', 'code-snippets' );
 			case 'head-content':
 				return __( 'Head content', 'code-snippets' );
+			case 'body-content':
+				return __( 'Body content', 'code-snippets' );
 			case 'footer-content':
 				return __( 'Footer content', 'code-snippets' );
 			case 'admin-css':
@@ -369,6 +373,8 @@ class Snippet extends Model {
 				return __( 'Front-end styles', 'code-snippets' );
 			case 'site-head-js':
 				return __( 'Head scripts', 'code-snippets' );
+			case 'site-body-js':
+				return __( 'Body scripts', 'code-snippets' );
 			case 'site-footer-js':
 				return __( 'Footer scripts', 'code-snippets' );
 		}

--- a/src/php/Utils/i18n.php
+++ b/src/php/Utils/i18n.php
@@ -24,7 +24,11 @@ array(
 	'site-css'       => __( 'Site front-end stylesheet', 'code-snippets' ),
 	'admin-css'      => __( 'Administration area stylesheet', 'code-snippets' ),
 	'site-head-js'   => __( 'JavaScript loaded in the site &amp;lt;head&amp;gt; section', 'code-snippets' ),
-	'site-footer-js' => __( 'JavaScript loaded just before the closing &amp;lt;/body&amp;gt; tag', 'code-snippets' ),
+	'site-body-js'   => __( 'JavaScript loaded at the start of the &amp;lt;body&amp;gt; tag', 'code-snippets' ),
+	'site-footer-js' => __( 'JavaScript loaded at the end of the &amp;lt;body&amp;gt; tag', 'code-snippets' ),
+	'head-content'   => __( 'HTML output in the &amp;lt;head&amp;gt; section', 'code-snippets' ),
+	'body-content'   => __( 'HTML output at the start of the &amp;lt;body&amp;gt; tag', 'code-snippets' ),
+	'footer-content' => __( 'HTML output at the end of the &amp;lt;body&amp;gt; tag', 'code-snippets' ),
 );
 
 // class-content-widget.php.

--- a/src/php/snippet-ops.php
+++ b/src/php/snippet-ops.php
@@ -64,7 +64,7 @@ function clean_active_snippets_cache( string $table_name, $scopes = false ) {
 	$scope_groups = $scopes
 		? [ $scopes ]
 		: [
-			[ 'head-content', 'footer-content' ],
+			[ 'head-content', 'body-content', 'footer-content' ],
 			[ 'global', 'single-use', 'front-end' ],
 			[ 'global', 'single-use', 'admin' ],
 		];

--- a/tests/e2e/code-snippets-evaluation.spec.ts
+++ b/tests/e2e/code-snippets-evaluation.spec.ts
@@ -198,6 +198,7 @@ test.describe('Code Snippets Evaluation', () => {
 		await helper.navigateToFrontend()
 		await helper.expectTextVisible('Hello World HTML snippet in body start!')
 		await helper.expectElementCount('text=Hello World HTML snippet in body start!', 1)
+		await helper.expectTextBeforeElement('Hello World HTML snippet in body start!', SELECTORS.THEME_MAIN_WRAPPER)
 	})
 
 	test('HTML snippet is evaluating correctly at body end', async () => {
@@ -211,6 +212,7 @@ test.describe('Code Snippets Evaluation', () => {
 		await helper.navigateToFrontend()
 		await helper.expectTextVisible('Hello World HTML snippet in body end!')
 		await helper.expectElementCount('text=Hello World HTML snippet in body end!', 1)
+		await helper.expectTextAfterElement('Hello World HTML snippet in body end!', SELECTORS.THEME_MAIN_WRAPPER)
 	})
 
 	test('HTML snippet works with shortcode in editor', async ({ page }) => {

--- a/tests/e2e/code-snippets-evaluation.spec.ts
+++ b/tests/e2e/code-snippets-evaluation.spec.ts
@@ -190,27 +190,27 @@ test.describe('Code Snippets Evaluation', () => {
 	test('HTML snippet is evaluating correctly at body start', async () => {
 		await helper.createAndActivateSnippet({
 			name: snippetName,
-			code: '<p>Hello World HTML snippet in body!</p>',
+			code: '<p>Hello World HTML snippet in body start!</p>',
 			type: 'HTML',
 			location: 'SITE_BODY'
 		})
 
 		await helper.navigateToFrontend()
-		await helper.expectTextVisible('Hello World HTML snippet in body!')
-		await helper.expectElementCount('text=Hello World HTML snippet in body!', 1)
+		await helper.expectTextVisible('Hello World HTML snippet in body start!')
+		await helper.expectElementCount('text=Hello World HTML snippet in body start!', 1)
 	})
 
 	test('HTML snippet is evaluating correctly at body end', async () => {
 		await helper.createAndActivateSnippet({
 			name: snippetName,
-			code: '<p>Hello World HTML snippet in end!</p>',
+			code: '<p>Hello World HTML snippet in body end!</p>',
 			type: 'HTML',
 			location: 'SITE_FOOTER'
 		})
 
 		await helper.navigateToFrontend()
-		await helper.expectTextVisible('Hello World HTML snippet in footer!')
-		await helper.expectElementCount('text=Hello World HTML snippet in footer!', 1)
+		await helper.expectTextVisible('Hello World HTML snippet in body end!')
+		await helper.expectElementCount('text=Hello World HTML snippet in body end!', 1)
 	})
 
 	test('HTML snippet works with shortcode in editor', async ({ page }) => {

--- a/tests/e2e/code-snippets-evaluation.spec.ts
+++ b/tests/e2e/code-snippets-evaluation.spec.ts
@@ -187,6 +187,32 @@ test.describe('Code Snippets Evaluation', () => {
 		await helper.expectElementCount('text=Hello World HTML snippet in header!', 1)
 	})
 
+	test('HTML snippet is evaluating correctly at body start', async () => {
+		await helper.createAndActivateSnippet({
+			name: snippetName,
+			code: '<p>Hello World HTML snippet in body!</p>',
+			type: 'HTML',
+			location: 'SITE_BODY'
+		})
+
+		await helper.navigateToFrontend()
+		await helper.expectTextVisible('Hello World HTML snippet in body!')
+		await helper.expectElementCount('text=Hello World HTML snippet in body!', 1)
+	})
+
+	test('HTML snippet is evaluating correctly at body end', async () => {
+		await helper.createAndActivateSnippet({
+			name: snippetName,
+			code: '<p>Hello World HTML snippet in end!</p>',
+			type: 'HTML',
+			location: 'SITE_FOOTER'
+		})
+
+		await helper.navigateToFrontend()
+		await helper.expectTextVisible('Hello World HTML snippet in footer!')
+		await helper.expectElementCount('text=Hello World HTML snippet in footer!', 1)
+	})
+
 	test('HTML snippet works with shortcode in editor', async ({ page }) => {
 		const snippetId = await createHtmlSnippetForEditor(helper, page, snippetName)
 		const pageUrl = await createPageWithShortcode(page, snippetId, snippetName)

--- a/tests/e2e/helpers/SnippetsTestHelper.ts
+++ b/tests/e2e/helpers/SnippetsTestHelper.ts
@@ -497,6 +497,56 @@ export class SnippetsTestHelper {
 		await expect(this.page.locator('body')).not.toContainText(text)
 	}
 
+	async expectTextBeforeElement(text: string, selector: string): Promise<void> {
+		const precedes = await this.page.evaluate(
+			({ text, selector }) => {
+				const node = document.evaluate(
+					`//p[contains(text(),"${text}")]`,
+					document,
+					null,
+					XPathResult.FIRST_ORDERED_NODE_TYPE,
+					null
+				).singleNodeValue
+
+				const reference = document.querySelector(selector)
+
+				if (!node || !reference) {
+					return null
+				}
+
+				return !!(reference.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_PRECEDING)
+			},
+			{ text, selector }
+		)
+
+		expect(precedes).toBe(true)
+	}
+
+	async expectTextAfterElement(text: string, selector: string): Promise<void> {
+		const follows = await this.page.evaluate(
+			({ text, selector }) => {
+				const node = document.evaluate(
+					`//p[contains(text(),"${text}")]`,
+					document,
+					null,
+					XPathResult.FIRST_ORDERED_NODE_TYPE,
+					null
+				).singleNodeValue
+
+				const reference = document.querySelector(selector)
+
+				if (!node || !reference) {
+					return null
+				}
+
+				return !!(reference.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING)
+			},
+			{ text, selector }
+		)
+
+		expect(follows).toBe(true)
+	}
+
 	/**
    * Create a complete snippet with save and activate
    */

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -43,7 +43,7 @@ export const SNIPPET_TYPES = <const>{
 }
 
 export const SNIPPET_LOCATIONS = <const>{
-	SITE_HEADER: 'In site <head> section',
+	SITE_HEADER: 'In site header (<head> section)',
 	SITE_BODY: 'In site content (start of <body>)',
 	SITE_FOOTER: 'In site footer (end of <body>)',
 	IN_EDITOR: 'Where inserted in editor',

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -43,8 +43,9 @@ export const SNIPPET_TYPES = <const>{
 }
 
 export const SNIPPET_LOCATIONS = <const>{
-	SITE_FOOTER: 'In site footer (end of <body>)',
 	SITE_HEADER: 'In site <head> section',
+	SITE_BODY: 'In site content (start of <body>)',
+	SITE_FOOTER: 'In site footer (end of <body>)',
 	IN_EDITOR: 'Where inserted in editor',
 	ADMIN_ONLY: 'Only run in administration area',
 	FRONTEND_ONLY: 'Only run on site front-end',

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -16,7 +16,8 @@ export const SELECTORS = <const>{
 	DELETE_ACTION: '.row-actions button:has-text("Trash")',
 	EXPORT_ACTION: '.row-actions button:has-text("Export")',
 
-	ADMIN_BAR: '#wpadminbar'
+	ADMIN_BAR: '#wpadminbar',
+	THEME_MAIN_WRAPPER: '.wp-site-blocks'
 }
 
 export const TIMEOUTS = <const>{


### PR DESCRIPTION
Currently the plugin supports 2 locations:

<img width="303" height="164" alt="Screenshot 2026-05-08 at 20 31 01" src="https://github.com/user-attachments/assets/cf1b4abe-29ef-4dd5-a7cf-38c13796e2c9" style="padding-block-end: 10px" />


However, WordPress supports 3 locations:

| WordPress location | Insert code to... | Code snippets support |
| ---- | ---- | ---- |
| [wp_head()](https://developer.wordpress.org/reference/functions/wp_head/) | Insert HTML/JS code to site header (to the `<head>` tag) | Supported |
| [wp_body_open()](https://developer.wordpress.org/reference/functions/wp_body_open/) | Insert HTML/JS code to site content (start of `<body>` tag) | Not supported (yet) |
| [wp_footer()](https://developer.wordpress.org/reference/functions/wp_footer/) | Insert HTML/JS code to site footer (end of `<body>` tag) | Supported |

This PR aims to add support for `wp_body_open` to code-snippets. To allow users the ability to insert code at the start of the `<body>` tag.

In pro:

<img width="300" height="231" alt="image" src="https://github.com/user-attachments/assets/cd1a8e6e-10d3-4830-ad64-13d644bbcdbb" />
