### PR TITLE
Bulk and single action handlers for Trash tab

### DIFF
--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -252,99 +252,141 @@ const NoItemsMessage = () => {
 		</>
 }
 
-const useBulkActions = (allSnippets: Snippet[]): ListTableBulkAction<Snippet['id']>[] => {
-	const { activate, deactivate, delete: trashOrDelete, create } = useSnippetsAPI()
+const useBulkActions = (
+	currentSnippets: Snippet[],
+	currentStatus: SnippetStatus
+): ListTableBulkAction<Snippet['id']>[] => {
+	const { activate, deactivate, delete: trashOrDelete, restore, create } = useSnippetsAPI()
 	const { refreshSnippetsList } = useSnippetsList()
 
 	return useMemo(
-		() => [
-			{
-				name: __('Activate', 'code-snippets'),
-				apply: async (selected: Set<Snippet['id']>) => {
-					const targets = allSnippets.filter(snippet => selected.has(snippet.id) && !snippet.active)
+		() => {
+			if ('trashed' === currentStatus) {
+				return [
+					{
+						name: __('Restore', 'code-snippets'),
+						apply: async (selected: Set<Snippet['id']>) => {
+							const targets = currentSnippets.filter(snippet => selected.has(snippet.id) && snippet.trashed)
 
-					if (0 === targets.length) {
-						return
+							if (0 === targets.length) {
+								return
+							}
+
+							for (const snippet of targets) {
+								await restore({ id: snippet.id, network: snippet.network }).catch(handleUnknownError)
+							}
+
+							await refreshSnippetsList()
+						}
+					},
+					{
+						name: __('Delete Permanently', 'code-snippets'),
+						apply: async (selected: Set<Snippet['id']>) => {
+							const targets = currentSnippets.filter(snippet => selected.has(snippet.id) && snippet.trashed)
+
+							if (0 === targets.length) {
+								return
+							}
+
+							for (const snippet of targets) {
+								await trashOrDelete({ id: snippet.id, network: snippet.network }).catch(handleUnknownError)
+							}
+
+							await refreshSnippetsList()
+						}
 					}
-
-					for (const snippet of targets) {
-						await activate({ id: snippet.id, network: snippet.network }).catch(handleUnknownError)
-					}
-
-					await refreshSnippetsList()
-				}
-			},
-			{
-				name: __('Deactivate', 'code-snippets'),
-				apply: async (selected: Set<Snippet['id']>) => {
-					const targets = allSnippets.filter(snippet => selected.has(snippet.id) && snippet.active)
-
-					if (0 === targets.length) {
-						return
-					}
-
-					for (const snippet of targets) {
-						await deactivate({ id: snippet.id, network: snippet.network }).catch(handleUnknownError)
-					}
-
-					await refreshSnippetsList()
-				}
-			},
-			{
-				name: __('Clone', 'code-snippets'),
-				apply: async (selected: Set<Snippet['id']>) => {
-					const targets = allSnippets.filter(snippet => selected.has(snippet.id) && !snippet.trashed)
-
-					if (0 === targets.length) {
-						return
-					}
-
-					for (const snippet of targets) {
-						await create(cloneSnippetObject(snippet)).catch(handleUnknownError)
-					}
-
-					await refreshSnippetsList()
-				}
-			},
-			{
-				name: __('Export', 'code-snippets'),
-				apply: (selected: Set<Snippet['id']>) => {
-					downloadBulkSnippetExportFile(
-						allSnippets.filter(snippet => selected.has(snippet.id))
-					)
-					return Promise.resolve()
-				}
-			},
-			{
-				name: __('Download', 'code-snippets'),
-				apply: (selected: Set<Snippet['id']>) => {
-					const selectedSnippets = allSnippets.filter(snippet => selected.has(snippet.id))
-
-					if (1 < selectedSnippets.length && !window.CODE_SNIPPETS_MANAGE?.supportsZipDownloads) {
-						return submitBulkSnippetDownloadsIndividually(selectedSnippets)
-					}
-
-					return submitBulkSnippetDownload(selectedSnippets)
-				}
-			},
-			{
-				name: __('Trash', 'code-snippets'),
-				apply: async (selected: Set<Snippet['id']>) => {
-					const targets = allSnippets.filter(snippet => selected.has(snippet.id))
-
-					if (0 === targets.length) {
-						return
-					}
-
-					for (const snippet of targets) {
-						await trashOrDelete({ id: snippet.id, network: snippet.network }).catch(handleUnknownError)
-					}
-
-					await refreshSnippetsList()
-				}
+				]
 			}
-		],
-		[allSnippets, activate, deactivate, trashOrDelete, create, refreshSnippetsList]
+
+			return [
+				{
+					name: __('Activate', 'code-snippets'),
+					apply: async (selected: Set<Snippet['id']>) => {
+						const targets = currentSnippets.filter(snippet => selected.has(snippet.id) && !snippet.active)
+
+						if (0 === targets.length) {
+							return
+						}
+
+						for (const snippet of targets) {
+							await activate({ id: snippet.id, network: snippet.network }).catch(handleUnknownError)
+						}
+
+						await refreshSnippetsList()
+					}
+				},
+				{
+					name: __('Deactivate', 'code-snippets'),
+					apply: async (selected: Set<Snippet['id']>) => {
+						const targets = currentSnippets.filter(snippet => selected.has(snippet.id) && snippet.active)
+
+						if (0 === targets.length) {
+							return
+						}
+
+						for (const snippet of targets) {
+							await deactivate({ id: snippet.id, network: snippet.network }).catch(handleUnknownError)
+						}
+
+						await refreshSnippetsList()
+					}
+				},
+				{
+					name: __('Clone', 'code-snippets'),
+					apply: async (selected: Set<Snippet['id']>) => {
+						const targets = currentSnippets.filter(snippet => selected.has(snippet.id) && !snippet.trashed)
+
+						if (0 === targets.length) {
+							return
+						}
+
+						for (const snippet of targets) {
+							await create(cloneSnippetObject(snippet)).catch(handleUnknownError)
+						}
+
+						await refreshSnippetsList()
+					}
+				},
+				{
+					name: __('Export', 'code-snippets'),
+					apply: (selected: Set<Snippet['id']>) => {
+						downloadBulkSnippetExportFile(
+							currentSnippets.filter(snippet => selected.has(snippet.id))
+						)
+						return Promise.resolve()
+					}
+				},
+				{
+					name: __('Download', 'code-snippets'),
+					apply: (selected: Set<Snippet['id']>) => {
+						const selectedSnippets = currentSnippets.filter(snippet => selected.has(snippet.id))
+
+						if (1 < selectedSnippets.length && !window.CODE_SNIPPETS_MANAGE?.supportsZipDownloads) {
+							return submitBulkSnippetDownloadsIndividually(selectedSnippets)
+						}
+
+						return submitBulkSnippetDownload(selectedSnippets)
+					}
+				},
+				{
+					name: __('Trash', 'code-snippets'),
+					apply: async (selected: Set<Snippet['id']>) => {
+						const targets = currentSnippets.filter(snippet => selected.has(snippet.id))
+
+						if (0 === targets.length) {
+							return
+						}
+
+						for (const snippet of targets) {
+							await trashOrDelete({ id: snippet.id, network: snippet.network }).catch(handleUnknownError)
+						}
+
+						await refreshSnippetsList()
+					}
+				}
+			]
+		},
+		[currentSnippets, currentStatus, activate, deactivate, trashOrDelete, restore, create, refreshSnippetsList]
 	)
 }
 
@@ -353,12 +395,15 @@ export const SnippetsListTable: React.FC = () => {
 	const { snippetsByStatus } = useFilteredSnippets()
 	const { hiddenColumns, truncateRowValues } = useManageTableSettings()
 
-	const allSnippets = useMemo(() => snippetsByStatus.get('all') ?? [], [snippetsByStatus])
-	const totalItems = snippetsByStatus.get(currentStatus)?.length ?? 0
+	const currentSnippets = useMemo(
+		() => snippetsByStatus.get(currentStatus) ?? [],
+		[snippetsByStatus, currentStatus]
+	)
+	const totalItems = currentSnippets.length
 	const itemsPerPage = window.CODE_SNIPPETS_MANAGE?.snippetsPerPage
 
 	const columns = useMemo(() => getTableColumns(hiddenColumns), [hiddenColumns])
-	const actions = useBulkActions(allSnippets)
+	const actions = useBulkActions(currentSnippets, currentStatus)
 
 	useEffect(() => {
 		if (INDEX_STATUS !== currentStatus && !snippetsByStatus.has(currentStatus)) {
@@ -380,7 +425,7 @@ export const SnippetsListTable: React.FC = () => {
 			</p>
 
 			<ListTable
-				items={snippetsByStatus.get(currentStatus) ?? []}
+				items={currentSnippets}
 				getKey={snippet => snippet.id}
 				ariaLabel={__('Snippets list', 'code-snippets')}
 				getCheckboxAriaLabel={(snippet: Snippet) => sprintf(

--- a/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
@@ -107,14 +107,14 @@ const ActionLinks = ({ snippet }: { snippet: Snippet }) => {
 			{__('Clone', 'code-snippets')}
 		</Button>)
 
-	const Export = () =>
+	const Export = !snippet.trashed && (() =>
 		<Button link onClick={() => {
 			api.export(snippet)
 				.then(response => downloadSnippetExportFile(response, snippet))
 				.catch(handleUnknownError)
 		}}>
 			{__('Export', 'code-snippets')}
-		</Button>
+		</Button>)
 
 	const Restore = snippet.trashed && (() =>
 		<Button link onClick={() => {

--- a/src/php/REST_API/Snippets/Snippets_REST_Controller.php
+++ b/src/php/REST_API/Snippets/Snippets_REST_Controller.php
@@ -572,9 +572,18 @@ final class Snippets_REST_Controller extends REST_Collection_Controller {
 	 */
 	public function delete_item( $request ) {
 		$item = $this->prepare_item_for_database( $request );
+		$snippet = get_snippet( $item->id, $item->network );
 
-		if ( $item->trashed ) {
-			return delete_snippet( $item->id, $item->network )
+		if ( ! $snippet || ! $snippet->id ) {
+			return new WP_Error(
+				'rest_cannot_delete',
+				__( 'The snippet could not be found.', 'code-snippets' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( $snippet->trashed ) {
+			return delete_snippet( $snippet->id, $snippet->network )
 				? new WP_REST_Response( null, 204 )
 				: new WP_Error(
 					'rest_cannot_delete',
@@ -582,7 +591,7 @@ final class Snippets_REST_Controller extends REST_Collection_Controller {
 					[ 'status' => 500 ]
 				);
 		} else {
-			return trash_snippet( $item->id, $item->network )
+			return trash_snippet( $snippet->id, $snippet->network )
 				? $this->get_item( $request )
 				: new WP_Error(
 					'rest_cannot_trash',


### PR DESCRIPTION
## Summary

Restores working bulk and single-row actions for the **Trash** tab on the Manage Snippets screen. After the React rewrite these were either no-ops or wired to the wrong code paths, so this PR re-introduces the legacy behaviour with the new React/REST stack.

## Changes

### Bulk actions on the Trash tab (`SnippetsListTable.tsx`)

- The bulk-action dropdown on the Trash tab now exposes only **Restore** and **Delete Permanently**, matching the legacy UI.
- Both actions iterate the selected snippets and call the REST API (`restore` / `delete`) per item, then refresh the list.
- The pool of snippets the action looks up by ID is now the snippets visible on the current tab (`snippetsByStatus.get(currentStatus)`), instead of `snippetsByStatus.get('all')`. Trashed snippets are only stored in the `'trashed'` bucket by `partitionSnippetsByStatus`, so filtering against `'all'` silently produced zero targets, which is why Apply appeared to do nothing.

### Single row actions on the Trash tab (`TableColumns.tsx`)

- Removed the **Export** link from the row actions for trashed snippets. Trashed rows now show only **Restore | Delete Permanently**, matching the legacy UI.
- **Restore** already worked. **Delete Permanently** is fixed by the server-side change below.

### Permanent delete via REST (`Snippets_REST_Controller.php`)

- `delete_item` previously decided "trash vs permanent delete" from `$item->trashed` on the request body. The client never sends that flag on a DELETE, so permanent deletes silently re-trashed already-trashed snippets (a no-op).
- It now loads the snippet from the database via `get_snippet()` and uses its real `trashed` state to choose between `trash_snippet()` and `delete_snippet()`. As a side benefit, clients can no longer override the server's view of the snippet state.

## Test plan

- [x] Trash tab: select one or more snippets, choose **Restore** → snippets leave the trash and reappear in their original status.
- [x] Trash tab: select one or more snippets, choose **Delete Permanently** → snippets are permanently removed and the trash counts decrement.
- [x] Trash tab single row: **Restore** link restores the snippet.
- [x] Trash tab single row: **Delete Permanently** link removes the snippet (with confirmation dialog).
- [x] Trash tab single row: **Export** link is no longer shown.
- [x] Non-trash tabs: existing bulk actions (Activate / Deactivate / Clone / Export / Download / Trash) still work.