### PR TITLE
fix: broken wordpress notices inside the toolbar

### DIFF
--- a/src/js/components/EditMenu/EditorSidebar/actions/ShortcodeInfo.tsx
+++ b/src/js/components/EditMenu/EditorSidebar/actions/ShortcodeInfo.tsx
@@ -109,6 +109,8 @@ const ModalContent = () => {
 
 			<h2>{__('Shortcode Options', 'code-snippets')}</h2>
 
+			<hr className="wp-header-end" />
+
 			<CheckboxList
 				options={['php', 'format', 'shortcodes']}
 				checked={options}

--- a/src/js/components/EditMenu/SnippetForm/page/PageHeading.tsx
+++ b/src/js/components/EditMenu/SnippetForm/page/PageHeading.tsx
@@ -27,36 +27,40 @@ export const PageHeading: React.FC = () => {
 	const { snippet, updateSnippet, setCurrentNotice } = useSnippetForm()
 
 	return (
-		<h2>
-			{snippet.id
-				? <>
-					{`${getPageHeading(snippet)} `}
+		<>
+			<h2>
+				{snippet.id
+					? <>
+						{`${getPageHeading(snippet)} `}
 
-					<a
-						href={window.CODE_SNIPPETS?.urls.addNew}
-						className="page-title-action"
-						onClick={event => {
-							event.preventDefault()
-							updateSnippet(({ scope }) => createSnippetObject({ scope }))
-							setCurrentNotice(undefined)
+						<a
+							href={window.CODE_SNIPPETS?.urls.addNew}
+							className="page-title-action"
+							onClick={event => {
+								event.preventDefault()
+								updateSnippet(({ scope }) => createSnippetObject({ scope }))
+								setCurrentNotice(undefined)
 
-							window.document.title = window.document.title
-								.replace(__('Edit Snippet', 'code-snippets'), getAddNewHeading(snippet))
-								.replace(__('Edit Condition', 'code-snippets'), getAddNewHeading(snippet))
+								window.document.title = window.document.title
+									.replace(__('Edit Snippet', 'code-snippets'), getAddNewHeading(snippet))
+									.replace(__('Edit Condition', 'code-snippets'), getAddNewHeading(snippet))
 
-							window.history.pushState({}, '', window.CODE_SNIPPETS?.urls.addNew)
-						}}
-					>
-						{_x('Add New', 'snippet', 'code-snippets')}
-					</a>
-				</>
-				: getAddNewHeading(snippet)}
+								window.history.pushState({}, '', window.CODE_SNIPPETS?.urls.addNew)
+							}}
+						>
+							{_x('Add New', 'snippet', 'code-snippets')}
+						</a>
+					</>
+					: getAddNewHeading(snippet)}
 
-			{OPTIONS?.pageTitleActions && Object.entries(OPTIONS.pageTitleActions).map(([label, url]) =>
-				<>
-					<a key={label} href={url} className="page-title-action">{label}</a>{' '}
-				</>
-			)}
-		</h2>
+				{OPTIONS?.pageTitleActions && Object.entries(OPTIONS.pageTitleActions).map(([label, url]) =>
+					<>
+						<a key={label} href={url} className="page-title-action">{label}</a>{' '}
+					</>
+				)}
+			</h2>
+
+			<hr className="wp-header-end" />
+		</>
 	)
 }

--- a/src/js/components/ImportMenu/ImportMenu.tsx
+++ b/src/js/components/ImportMenu/ImportMenu.tsx
@@ -39,6 +39,8 @@ export const ImportMenu: React.FC = () => {
 			<>
 				<h2>{__('Import Snippets', 'code-snippets')}</h2>
 
+				<hr className="wp-header-end" />
+
 				<nav
 					className="nav-tab-wrapper"
 					aria-label={__('Import sources', 'code-snippets')}

--- a/src/js/components/ManageMenu/CommunityCloud/CommunityCloud.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/CommunityCloud.tsx
@@ -26,6 +26,8 @@ export const CommunityCloud = () => {
 		<>
 			<h2>{__('Community Cloud', 'code-snippets')}</h2>
 
+			<hr className="wp-header-end" />
+
 			<nav
 				className="nav-tab-wrapper"
 				aria-label={__('Community Cloud types', 'code-snippets')}

--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsTable.tsx
@@ -89,6 +89,8 @@ const PageHeading = () => {
 					: null}
 			</h2>
 
+			<hr className="wp-header-end" />
+
 			<SafeModeNotice />
 		</>
 	)

--- a/src/js/components/WelcomeMenu/WelcomeMenu.tsx
+++ b/src/js/components/WelcomeMenu/WelcomeMenu.tsx
@@ -103,6 +103,8 @@ export const WelcomeMenu = () =>
 		<div className="code-snippets-welcome">
 			<h2>{__('Resources and Updates', 'code-snippets')}</h2>
 
+			<hr className="wp-header-end" />
+
 			<div className="code-snippets-updates">
 				<HeroImage />
 				<Changelog />

--- a/src/js/components/common/Toolbar.tsx
+++ b/src/js/components/common/Toolbar.tsx
@@ -166,13 +166,10 @@ export const Toolbar = () => {
 	const [isUpsellDialogOpen, setIsUpsellDialogOpen] = useState(false)
 
 	return (
-		<>
-			<div className="code-snippets-toolbar">
-				<UpperNav setIsUpsellDialogOpen={setIsUpsellDialogOpen} />
-				<LowerNav setIsUpsellDialogOpen={setIsUpsellDialogOpen} />
-				<UpsellDialog isOpen={isUpsellDialogOpen} setIsOpen={setIsUpsellDialogOpen} />
-			</div>
-			<hr className="wp-header-end" />
-		</>
+		<div className="code-snippets-toolbar">
+			<UpperNav setIsUpsellDialogOpen={setIsUpsellDialogOpen} />
+			<LowerNav setIsUpsellDialogOpen={setIsUpsellDialogOpen} />
+			<UpsellDialog isOpen={isUpsellDialogOpen} setIsOpen={setIsUpsellDialogOpen} />
+		</div>
 	)
 }

--- a/src/php/Admin/Menus/Settings_Menu.php
+++ b/src/php/Admin/Menus/Settings_Menu.php
@@ -221,6 +221,8 @@ class Settings_Menu extends Admin_Menu {
 				?>
 			</h2>
 
+			<hr class="wp-header-end" />
+
 			<?php settings_errors( OPTION_NAME ); ?>
 
 			<form action="<?php echo esc_url( $update_url ); ?>" method="post">


### PR DESCRIPTION
WordPress notices placed in the Toolbar (where `<h1>` is located), instead of the content (where `<h2>` is located).

**Before:**

<img width="1566" height="368" alt="image" src="https://github.com/user-attachments/assets/de4f6069-4ad3-4371-ab2b-30e790695195" />


**After:**

<img width="1548" height="530" alt="image" src="https://github.com/user-attachments/assets/731614d5-e742-430e-bc74-a0f55b478189" />
