### PR TITLE
Fix get_item() returning HTTP 500 for a not-found snippet

### DIFF
--- a/src/php/REST_API/Snippets/Snippets_REST_Controller.php
+++ b/src/php/REST_API/Snippets/Snippets_REST_Controller.php
@@ -504,7 +504,7 @@ final class Snippets_REST_Controller extends REST_Collection_Controller {
 			return new WP_Error(
 				'rest_cannot_get',
 				__( 'The snippet could not be found.', 'code-snippets' ),
-				[ 'status' => 500 ]
+				[ 'status' => 404 ]
 			);
 		}
 


### PR DESCRIPTION
Hey folks,

get_item() in the REST controller returns HTTP 500 when a snippet ID doesn't exist. That should be 404 — 500 means something went wrong on the server, 404 means the resource doesn't exist. The activate_item() and deactivate_item() methods in the same file already return 404 for the same not-found condition, so get_item() was just the odd one out. One digit change.

(full disclosure, I used AI help with the testing and tweaks - Christopher)