### PR TITLE
docs: codify commit message and code comment conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,12 @@ Tool-specific configuration lives in dedicated locations:
 - Use `__()`, `_e()`, `esc_html__()`, `esc_attr__()`, `_x()`, `_n()` as appropriate — never echo raw translatable strings.
 - Do not load translations before `init` or `plugins_loaded`.
 
+### Code Comments
+
+- A comment must state a current constraint or behaviour the code itself cannot show — written for the next reader, not the reviewer.
+- Do not write comments that narrate what the next line does, justify why a change is correct, or argue with the previous implementation ("not a no-op", "this used to…", "fixes the bug where…"). History belongs in the commit message.
+- Match the comment density and tone of the surrounding file; when in doubt, omit the comment.
+
 ### PHP
 
 - Namespace: `Code_Snippets\` — all new classes must live under this namespace and be PSR-4 autoloaded.
@@ -123,6 +129,14 @@ Tool-specific configuration lives in dedicated locations:
 - Open PRs back into `core-beta`.
 - Use **merge commits** (not squash/rebase) when merging dev branches into `core-beta`.
 - Hotfixes branch from `core` and merge directly back into `core`.
+
+### Commit Messages
+
+- Single-line conventional commit messages only — no body, no trailers.
+- The subject must start with exactly one of: `fix:`, `feat:`, `chore:`, `docs:`.
+- No scope in parentheses — write `fix: restore cloud search`, never `fix(cloud): …`.
+- No co-author lines or any other trailers (`Co-Authored-By:`, `Signed-off-by:`, etc.).
+- Scope each commit to one feature, one change, or one file — do not bundle unrelated changes.
 
 ---
 


### PR DESCRIPTION
Adds two sections to `AGENTS.md` (the single source of truth all tool shims point to):

- **Commit Messages** — single-line conventional commits starting with `fix:`/`feat:`/`chore:`/`docs:` only, no scope parentheses, no co-author or other trailers, one concern per commit.
- **Code Comments** — comments state current constraints the code cannot show; no narration, no change-justification, no arguing with previous implementations — history belongs in the commit message.

Codifies conventions already practised in review so all agents (Claude Code, Codex, Cursor, Copilot) inherit them from one place.