### PR TITLE
fix: accept an uppercase status token in changelog release headers

### DIFF
--- a/scripts/linters/lint-changelog.ts
+++ b/scripts/linters/lint-changelog.ts
@@ -156,10 +156,10 @@ const promoteBoldChangeTypeLabels = (lines: string[]): string[] =>
 
 const normaliseReleaseHeaders = (lines: string[], errors: string[]): string[] =>
 	lines.map(line => {
-		const bracketed = /^## \[(?<ver>[^\]]+)\]\s*\((?<date>\d{4}-\d{2}-\d{2})\)/.exec(line)
+		const bracketed = /^## \[(?<ver>[^\]]+)\]\s*\((?<date>\d{4}-\d{2}-\d{2}|[A-Z][A-Z0-9-]*)\)/.exec(line)
 		if (bracketed?.groups) {return `## [${bracketed.groups.ver}] (${bracketed.groups.date})`}
 
-		const bracketedMissingClose = /^## \[(?<ver>[^\]]+)\]\s*\((?<date>\d{4}-\d{2}-\d{2})$/.exec(line)
+		const bracketedMissingClose = /^## \[(?<ver>[^\]]+)\]\s*\((?<date>\d{4}-\d{2}-\d{2}|[A-Z][A-Z0-9-]*)$/.exec(line)
 		if (bracketedMissingClose?.groups) {
 			return `## [${bracketedMissingClose.groups.ver}] (${bracketedMissingClose.groups.date})`
 		}
@@ -170,7 +170,7 @@ const normaliseReleaseHeaders = (lines: string[], errors: string[]): string[] =>
 			return line
 		}
 
-		const plain = /^## (?<ver>\d[^\s(]+)\s*(?:\((?<date>\d{4}-\d{2}-\d{2})\))?/.exec(line)
+		const plain = /^## (?<ver>\d[^\s(]+)\s*(?:\((?<date>\d{4}-\d{2}-\d{2}|[A-Z][A-Z0-9-]*)\))?/.exec(line)
 		if (!plain?.groups) {return line}
 		if (plain.groups.date) {return `## [${plain.groups.ver}] (${plain.groups.date})`}
 		errors.push(`CHANGELOG.md: Release header missing date: ${line}`)

--- a/scripts/linters/lint-readme.ts
+++ b/scripts/linters/lint-readme.ts
@@ -20,7 +20,7 @@
  *     Screenshots, Changelog, Upgrade Notice
  *
  * Changelog section (inside readme.txt)
- *   - Version sub-headers: = X.Y.Z (YYYY-MM-DD) =
+ *   - Version sub-headers: = X.Y.Z (YYYY-MM-DD) = or an uppercase status token, e.g. = X.Y.Z (UPCOMING) =
  *   - Change-type labels: __Added__, __Changed__, __Fixed__, __Removed__,
  *     __Deprecated__, __Security__
  *     (### headings and **Bold** variants are demoted / normalised)
@@ -51,7 +51,7 @@ const CLI_ARGS_START_INDEX = 2
 const SUBSECTION_TITLECASE_MAX_WORDS = 2
 const LIST_MARKER_LENGTH = 2
 
-const RE_DATE_SRC = '\\d{4}-\\d{2}-\\d{2}'
+const RE_DATE_SRC = '(?:\\d{4}-\\d{2}-\\d{2}|[A-Z][A-Z0-9-]*)'
 const RE_VERSION_SRC = '\\d+\\.\\d+(?:\\.\\d+)*(?:-[a-zA-Z0-9.]+)?'
 
 /** Known == Section == names (canonical capitalisation). */


### PR DESCRIPTION
The changelog and readme linters now accept either a date `(YYYY-MM-DD)` or a single uppercase status token (uppercase letters, digits, dashes) in a release header, e.g. `## [4.0.0] (UPCOMING)` and `= 4.0.0 (UPCOMING) =`. Lowercase or missing values are still rejected by the changelog linter. Existing dated entries are unaffected.