### PR TITLE
fix: featured snippets retrieval against the snippets-only cloud response

### DIFF
--- a/src/php/Client/Cloud_API.php
+++ b/src/php/Client/Cloud_API.php
@@ -509,15 +509,9 @@ class Cloud_API {
 			return new Cloud_Snippets();
 		}
 
-		$body = wp_remote_retrieve_body( $response );
+		$json = self::unpack_request_json( $response );
 
-		if ( ! $body ) {
-			return new Cloud_Snippets();
-		}
-
-		$json = json_decode( $body, true );
-
-		if ( ! is_array( $json ) || ! isset( $json['data'] ) ) {
+		if ( ! $json ) {
 			return new Cloud_Snippets();
 		}
 

--- a/src/php/Model/Cloud_Snippets.php
+++ b/src/php/Model/Cloud_Snippets.php
@@ -107,7 +107,7 @@ class Cloud_Snippets extends Model {
 		if ( is_array( $initial_data ) ) {
 			$meta = $initial_data['meta'] ?? [];
 
-			$result['snippets'] = $initial_data['data'] ?? $initial_data['snippets'] ?? [];
+			$result['snippets'] = $initial_data['snippets'] ?? [];
 			$result['cloud_id_rev'] = $initial_data['cloud_id_rev'] ?? [];
 
 			if ( $meta ) {

--- a/tests/phpunit/test-cloud-api-featured.php
+++ b/tests/phpunit/test-cloud-api-featured.php
@@ -127,7 +127,6 @@ class Cloud_API_Featured_Test extends TestCase {
 		}
 
 		$body = [
-			'data'              => $snippets,
 			'snippets'          => $snippets,
 			'meta'              => [
 				'total'       => $count,

--- a/tests/phpunit/test-cloud-api-search.php
+++ b/tests/phpunit/test-cloud-api-search.php
@@ -88,7 +88,7 @@ class Cloud_API_Search_Test extends TestCase {
 		}
 
 		$body = [
-			'data'              => $snippets,
+			'snippets'          => $snippets,
 			'meta'              => [
 				'total'       => $total,
 				'total_pages' => 5,

--- a/tests/phpunit/test-cloud-snippets.php
+++ b/tests/phpunit/test-cloud-snippets.php
@@ -20,7 +20,7 @@ class Cloud_Snippets_Test extends TestCase {
 	public function test_normalizes_full_envelope(): void {
 		$result = new Cloud_Snippets(
 			[
-				'data'              => [
+				'snippets'          => [
 					[
 						'id'   => 1,
 						'name' => 'First',
@@ -57,11 +57,11 @@ class Cloud_Snippets_Test extends TestCase {
 	}
 
 	/**
-	 * The `snippets` key is used when no `data` key is present.
+	 * Snippets are read from the `snippets` key of the envelope.
 	 *
 	 * @return void
 	 */
-	public function test_falls_back_to_snippets_key(): void {
+	public function test_reads_snippets_key(): void {
 		$result = new Cloud_Snippets(
 			[
 				'snippets' => [
@@ -79,11 +79,11 @@ class Cloud_Snippets_Test extends TestCase {
 	}
 
 	/**
-	 * The `data` key takes precedence over the `snippets` key when both are present.
+	 * The `snippets` key is authoritative; a legacy `data` key is ignored.
 	 *
 	 * @return void
 	 */
-	public function test_data_key_takes_precedence_over_snippets_key(): void {
+	public function test_legacy_data_key_is_ignored(): void {
 		$result = new Cloud_Snippets(
 			[
 				'data'     => [
@@ -99,14 +99,14 @@ class Cloud_Snippets_Test extends TestCase {
 				'snippets' => [
 					[
 						'id'   => 9,
-						'name' => 'Ignored',
+						'name' => 'Used',
 					],
 				],
-				'meta'     => [ 'total' => 2 ],
+				'meta'     => [ 'total' => 1 ],
 			]
 		);
 
-		$this->assertCount( 2, $result->snippets );
+		$this->assertCount( 1, $result->snippets );
 	}
 
 	/**
@@ -161,7 +161,7 @@ class Cloud_Snippets_Test extends TestCase {
 	public function test_missing_meta_keeps_default_totals(): void {
 		$result = new Cloud_Snippets(
 			[
-				'data' => [
+				'snippets' => [
 					[
 						'id'   => 1,
 						'name' => 'Lonely',


### PR DESCRIPTION
## Summary

Featured snippets returned empty after the cloud-app dropped the redundant `data` alias from search/featured responses (now `snippets`-only).

`Cloud_API::get_featured_snippets()` had its own inline parse requiring `isset($json['data'])`, separate from the shared `unpack_request_json()` helper, so it returned an empty `Cloud_Snippets` once `data` was gone.

## Changes

* `get_featured_snippets()` now parses via `unpack_request_json()` (the full envelope), matching the search path.
* `Cloud_Snippets` reads snippets from the `snippets` key only; the legacy `data` fallback is removed.
* Taxonomy parsers (`get_cloud_types`/`get_cloud_categories`) are unchanged — those endpoints still return `data`.
* Test fixtures for featured/search now mirror the real snippets-only response.

## Verification

* `phpunit --group cloud`: 30/30 pass.
* Live against staging (snippets-only): featured returns 10/10 snippets (was 0 before the fix).