### PR TITLE
fix: exclude trashed snippets from the inactive status count

### DIFF
--- a/src/js/components/ManageMenu/SnippetsTable/WithFilteredSnippetsContext.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/WithFilteredSnippetsContext.tsx
@@ -17,7 +17,10 @@ const pushToMapArray = <K, V>(map: Map<K, V[]>, key: K, value: V) => {
 const partitionSnippetsByStatus = (snippets: Snippet[]): Map<SnippetStatus, Snippet[]> =>
 	snippets.reduce((acc, snippet) => {
 		pushToMapArray(acc, snippet.trashed ? 'trashed' : 'all', snippet)
-		pushToMapArray(acc, snippet.active ? 'active' : 'inactive', snippet)
+
+		if (!snippet.trashed) {
+			pushToMapArray(acc, snippet.active ? 'active' : 'inactive', snippet)
+		}
 		pushToMapArray(acc, snippet.locked ? 'locked' : 'unlocked', snippet)
 
 		if (snippet.lastActive) {


### PR DESCRIPTION
## Summary

Trashed snippets were counted in the Inactive status tally on the manage screen. The badge showed n+1 while items sat in the trash and corrected after permanent delete.

## Changes

* `WithFilteredSnippetsContext.tsx`: a trashed snippet (`active = -1`, `active` resolves to false) is no longer pushed into the `inactive` bucket; it lands only in `trashed`.

## Scope

* Counts only; list contents were already correct (server filter excludes trashed).