### PR TITLE
fix: prevent assert string evaluation in REST controller on PHP 7

### DIFF
--- a/src/php/REST_API/REST_Controller.php
+++ b/src/php/REST_API/REST_Controller.php
@@ -36,7 +36,7 @@ abstract class REST_Controller {
 	 */
 	public function __construct() {
 		assert( static::VERSION > 0, get_class( $this ) . '::VERSION must be set' );
-		assert( static::BASE_ROUTE, get_class( $this ) . '::BASE_ROUTE must be set' );
+		assert( static::BASE_ROUTE !== '', get_class( $this ) . '::BASE_ROUTE must be set' );
 
 		$this->namespace = REST_API_NAMESPACE . static::VERSION;
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );


### PR DESCRIPTION
## Summary

On PHP 7.x with assertions active, `assert()` evaluates a string first argument as PHP code. `REST_Controller::__construct()` passed `static::BASE_ROUTE` (a route string) directly to `assert()`, so PHP tried to execute each route value as code.

Reported from a live PHP 7.4 site: every registered REST controller emitted warnings — `Use of undefined constant recently/active/import/plugins/file/upload`, `A non-numeric value encountered` (`recently-active` parsed as subtraction), and `Division by zero` (routes containing `/`).

PHP 8 removed string evaluation in `assert()`, so this only affects PHP 7.x.

## Change

```php
assert( static::BASE_ROUTE !== '', get_class( $this ) . '::BASE_ROUTE must be set' );
```

A boolean first argument is never evaluated as a string, on any PHP version, and preserves the original intent. The sibling `Model::__construct()` assert is unaffected — its argument is an array, not a string.

## Verification

* phpcs clean, `php -l` clean.
* REST test suite: 47/47 pass.