### PR TITLE
fix: remove `<h1>` heading from the toolbar

### DIFF
--- a/src/css/common/_toolbar.scss
+++ b/src/css/common/_toolbar.scss
@@ -45,6 +45,11 @@ $wpcontent-inline-start-indent: 20px;
 		img {
 			block-size: 42px;
 		}
+
+		div {
+			font-size: 18px;
+			font-weight: 700;
+		}
 	}
 
 	h1 {

--- a/src/js/components/common/Toolbar.tsx
+++ b/src/js/components/common/Toolbar.tsx
@@ -93,7 +93,7 @@ const UpperNav: React.FC<UpperNavProps> = ({ setIsUpsellDialogOpen }) =>
 				aria-hidden="true"
 			/>
 
-			<h1>{__('Code Snippets', 'code-snippets')}</h1>
+			<div>{__('Code Snippets', 'code-snippets')}</div>
 		</div>
 
 		<nav aria-label={__('Main links', 'code-snippets')}>


### PR DESCRIPTION
Currently each admin page has two `<h1>` tags. One in the toolbar, and the other the actual page heading. This PR removes the `<h1>` tag from the toolbar.