### PR TITLE
feat: prepare releases on release branches

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,4 +1,4 @@
-name: "(Tag): Create"
+name: "(Release): Create Tag"
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ on:
       - pro-beta
 jobs:
   create-tag:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'tag/v')
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,4 +1,4 @@
-name: "(Tag): Prepare"
+name: "(Release): Prepare"
 
 permissions:
   contents: write
@@ -9,10 +9,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to create the tag for (e.g. 3.6.9) or `next`'
+        description: 'Version to prepare the release for (e.g. 3.6.9) or `next`'
         required: true
         type: string
         default: next
+      auto_changelog:
+        description: 'Auto-create changelog and readme entries with AI'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   version:
@@ -66,7 +71,7 @@ jobs:
           workflow_file="${{ steps.validate.outputs.workflow_file }}"
           version="${{ needs.version.outputs.version || github.event.inputs.version }}"
           
-          echo "::notice::Dispatching workflow '$workflow_file' to generate changelog and readme entries..."
+          echo "::notice::Dispatching workflow '$workflow_file' to prepare the release pull request..."
           echo "   Calling repo: $target_repo"
           echo "   Version: $version"
           echo "   Changelog path: ${GITHUB_EVENT_INPUTS_CHANGELOG_PATH:-./CHANGELOG.md}"
@@ -79,19 +84,26 @@ jobs:
             --field repo="${{ github.repository }}" \
             --field branch="${{ github.ref_name }}" \
             --field version="$version" \
-            --field readme_path="./src/readme.txt" ; then
+            --field readme_path="./src/readme.txt" \
+            --field generate_changelog="${{ github.event.inputs.auto_changelog }}" ; then
             echo "::error::Failed to dispatch workflow '$workflow_file' in $target_repo"
             exit 1
           fi
+
+          # Runs are identified by their run-name so concurrent dispatches from
+          # the other repository are never mistaken for this one.
+          echo "expected_title=Prepare release v$version for ${{ github.repository }}" >> $GITHUB_OUTPUT
           
           echo "::notice::Successfully dispatched changelog generation"
           
           # Wait a moment for the run to be created
           echo "Waiting for workflow run to be created..."
           sleep 10
-          
+
           # Get the workflow run URL for monitoring
-          if run_url=$(gh run list --repo "$target_repo" --workflow "$workflow_file" --limit 1 --json url -q '.[0].url' 2>/dev/null); then
+          if run_url=$(gh run list --repo "$target_repo" --workflow "$workflow_file" --limit 15 \
+            --json url,displayTitle \
+            -q "[.[] | select(.displayTitle == \"Prepare release v$version for ${{ github.repository }}\")][0].url" 2>/dev/null); then
             if [ -n "$run_url" ] && [ "$run_url" != "null" ]; then
               echo "::notice::Workflow run: $run_url"
               echo "run_url=$run_url" >> $GITHUB_OUTPUT
@@ -104,21 +116,22 @@ jobs:
         run: |
           target_repo="${{ steps.validate.outputs.target_repo }}"
           workflow_file="${{ steps.validate.outputs.workflow_file }}"
+          expected_title="${{ steps.dispatch.outputs.expected_title }}"
           max_attempts=30
           attempt=0
-          
+
           echo "::notice::Monitoring workflow completion..."
-          
+
           while [ $attempt -lt $max_attempts ]; do
             attempt=$((attempt + 1))
-            
-            # Get latest run status
+
+            # Get the status of this dispatch's run, matched by its run-name
             run_data=$(gh run list \
               --repo "$target_repo" \
               --workflow "$workflow_file" \
-              --limit 1 \
-              --json status,conclusion,url \
-              -q '.[0] | [.status, .conclusion, .url] | @tsv' 2>/dev/null)
+              --limit 15 \
+              --json status,conclusion,url,displayTitle \
+              -q "[.[] | select(.displayTitle == \"$expected_title\")][0] | [.status, .conclusion, .url] | @tsv" 2>/dev/null)
             
             if [ -n "$run_data" ]; then
               status=$(echo "$run_data" | cut -f1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,30 @@ jobs:
         with:
           files: ${{ steps.zip.outputs.path }}
 
+  sync-pro:
+    # Only core releases sync downstream; this job is inert in the pro repository.
+    if: github.repository == 'codesnippetspro/code-snippets'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch core to pro sync workflow
+        env:
+          GH_TOKEN: ${{ secrets.CHANGELOG_PAT }}
+        run: |
+          target_repo="codesnippetspro/.github-private"
+          workflow_file="sync-core-to-pro.yml"
+
+          echo "::notice::Dispatching core to pro sync for ${{ github.event.release.tag_name }}"
+
+          if ! gh workflow run "$workflow_file" \
+            --repo "$target_repo" \
+            --ref main \
+            --field tag="${{ github.event.release.tag_name }}"; then
+            echo "::error::Failed to dispatch $workflow_file in $target_repo"
+            exit 1
+          fi
+
+          echo "::notice::Successfully dispatched core to pro sync"
+
   deploy:
     needs: [build, upload]
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,10 @@ plugins.
 - **Production branch:** `core`
 - **Pre-release branch:** `core-beta`
 - **Development branches:** `feat/…`, `fix/…`, `chore/…`, `hotfix/…`
-- When creating the same logical branch on both remotes, suffix the Core branch with `-core` and the Pro branch with
-  `-pro` (for example, `chore/align-agent-rules-core` and `chore/align-agent-rules-pro`).
+- Name every new branch with an edition suffix as its final path segment: `/core` in the Core repository and `/pro`
+  in the Pro repository (for example, `chore/align-agent-rules/core` and `chore/align-agent-rules/pro`). Repository
+  rules reject branch creation without the suffix. Release automation follows the same pattern
+  (`release/v…/core`, `sync/core-v…/pro`).
 - Branch from `core-beta` for all feature and fix work.
 - Open PRs back into `core-beta`.
 - Preserve granular history during development and use merge commits for active stack propagation. Squash-merging a


### PR DESCRIPTION
Renames the release preparation flow from tag branches to release branches, adds an optional AI changelog toggle, and dispatches the core-to-pro sync when a release is created. Companion to codesnippetspro/.github-private#1.

## Changes

- `prepare-tag.yml` renamed to `prepare-release.yml` ("(Release): Prepare"). New `auto_changelog` boolean input, default off: the release branch, version bump and pull request are always prepared; AI changelog and readme generation only runs when the box is ticked. Run monitoring now matches the dispatched run by name instead of taking the most recent run, so concurrent dispatches from the other repository are never confused.
- `create-tag.yml` matches `release/v*` head branches. The new branch scheme is `release/v{version}/{edition}`, which satisfies the "Enforce branch suffixes" ruleset — the old `tag/v*` names have been blocked by it since the ruleset was created.
- `release.yml` gains a `sync-pro` job that dispatches `sync-core-to-pro.yml` when a release is created. Guarded to the core repository, so the job is inert in pro. Stable tags open a staged pull request into `pro`, beta tags into `pro-beta`; conflicts are AI-resolved where possible and listed for review, and the pull request is never merged automatically.
- `AGENTS.md` branch naming aligned with the ruleset: edition suffix as the final path segment (`/core`, `/pro`) instead of the dash form the ruleset rejects.

## Merge order

1. This pull request (and its twin in the other repository, on all release branches).
2. codesnippetspro/.github-private#1, which flips the shared workflow to the new branch names.
