### PR TITLE
Refactor: remove unnecessary heading from TagsEditor component

### DIFF
--- a/src/js/components/EditMenu/SnippetForm/fields/TagsEditor.tsx
+++ b/src/js/components/EditMenu/SnippetForm/fields/TagsEditor.tsx
@@ -10,10 +10,6 @@ export const TagsEditor: React.FC = () => {
 
 	return options?.enabled
 		? <div className="snippet-tags-container">
-			<h2>
-				<label htmlFor="components-form-token-input-0">{__('Snippet Tags', 'code-snippets')}</label>
-			</h2>
-
 			<FormTokenField
 				label={__('Snippet Tags', 'code-snippets')}
 				value={snippet.tags}


### PR DESCRIPTION
Before:

<img width="1107" height="743" alt="image" src="https://github.com/user-attachments/assets/6ebb9d2e-dab8-494b-9b80-cf7f2d5c100c" />


After:

<img width="1105" height="773" alt="image" src="https://github.com/user-attachments/assets/f1a0e4a3-49b8-41d9-bbbe-5033448bc542" />
